### PR TITLE
【自荐】基于 Cloudflare 的免费网页归档和分享工具 web-archive

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -167,6 +167,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [CloudFlare Radar](https://radar.cloudflare.com/scan) | Überprüfen Sie die Technologie-Stack einer Webseite. | | Wird gewartet |
 | [wr.do](https://github.com/oiov/wr.do) | Ein auf Cloudflare basierendes Multi-Tenant-DNS-Verteilungssystem. Open-Source und bietet kostenlose DNS-Auflösung und Kurzlink-Generierung an. |  https://wr.do |Aktiv |
 | [cloudflare-proxy-sites](https://github.com/seadfeng/cloudflare-proxy-sites) | Ein Cloudflare Workers-Web-Proxy mit Subdomain-Zugriffsmethode. | [Demo](https://www.proxysites.ai.serp.ing/) | Aktiv |
+| [web-archive](https://github.com/Ray-D-Song/web-archive) | Basierend auf Cloudflare ist ein kostenloses Tool zum Archivieren und Teilen von Webseiten. Es enthält ein Browser-Plugin und einen Dienst, der auf Cloudflare-Seiten läuft. | https://github.com/Ray-D-Song/web-archive | Aktiv |
 
 
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -202,6 +202,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [cloudflare-quickstart](https://github.com/zgimszhd61/cloudflare-quickstart) | A quick start guide to help you get started with Cloudflare Workers |  | Updating |
 | [cloudflare-tunnel](https://dmesg.app/cloudflare) | A series of technical blogs on using Cloudflare Zero Trust to create large intranets and solve issues with blocked servers. | | Updating |
 | [cloudflare-worker-gmail-resend-enterprise-email](https://cleanclip.cc/zh/developer/cloudflare-worker-gmail-resend-enterprise-email) | Cloudflare + Gmail + Resend: Get a Free Enterprise Email in Ten Minutes with Ease. |  | Updating |
+| [web-archive](https://github.com/Ray-D-Song/web-archive) | A free web archiving and sharing tool based on Cloudflare. It includes a browser plugin and a service running on Cloudflare pages. | https://github.com/Ray-D-Song/web-archive | Updating |
 
 ## Group
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -193,6 +193,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [CloudFlare Radar](https://radar.cloudflare.com/scan) | Check a website's technology stack. || Under maintenance |
 | [wr.do](https://github.com/oiov/wr.do) | A multi-tenant DNS distribution system based on Cloudflare. Open-source and freely provides DNS resolution and short link generation. |https://wr.do | Under maintenance|
 | [cloudflare-proxy-sites](https://github.com/seadfeng/cloudflare-proxy-sites) | A Cloudflare Workers web proxy with subdomain access method. | [Demo](https://www.proxysites.ai.serp.ing/) | Under maintenance|
+| [web-archive](https://github.com/Ray-D-Song/web-archive) | A free web archiving and sharing tool based on Cloudflare. It includes a browser plugin and a service running on Cloudflare pages. | https://github.com/Ray-D-Song/web-archive | Updating |
 
 
 ## Tutorials
@@ -202,7 +203,6 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [cloudflare-quickstart](https://github.com/zgimszhd61/cloudflare-quickstart) | A quick start guide to help you get started with Cloudflare Workers |  | Updating |
 | [cloudflare-tunnel](https://dmesg.app/cloudflare) | A series of technical blogs on using Cloudflare Zero Trust to create large intranets and solve issues with blocked servers. | | Updating |
 | [cloudflare-worker-gmail-resend-enterprise-email](https://cleanclip.cc/zh/developer/cloudflare-worker-gmail-resend-enterprise-email) | Cloudflare + Gmail + Resend: Get a Free Enterprise Email in Ten Minutes with Ease. |  | Updating |
-| [web-archive](https://github.com/Ray-D-Song/web-archive) | A free web archiving and sharing tool based on Cloudflare. It includes a browser plugin and a service running on Cloudflare pages. | https://github.com/Ray-D-Song/web-archive | Updating |
 
 ## Group
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -194,7 +194,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [CloudFlare Radar](https://radar.cloudflare.com/scan) | Verifique el stack tecnológico de un sitio web. | | En mantenimiento |
 | [wr.do](https://github.com/oiov/wr.do) | Un sistema de distribución de DNS multiinquilino basado en Cloudflare. Código abierto y proporciona resolución de DNS y generación de enlaces cortos de forma gratuita. | https://wr.do |  En mantenimiento |
 | [cloudflare-proxy-sites](https://github.com/seadfeng/cloudflare-proxy-sites) | Un proxy web de Cloudflare Workers con método de acceso mediante subdominios. | [Demo](https://www.proxysites.ai.serp.ing/) | En mantenimiento |
-
+| [web-archive](https://github.com/Ray-D-Song/web-archive) | Herramienta gratuita de archivo y compartición de páginas web basada en Cloudflare. Incluye un complemento de navegador y un servicio que se ejecuta en la página de Cloudflare. | https://github.com/Ray-D-Song/web-archive | Aktiv |
 
 
 ## Tutoriales

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@
 | [CloudFlare Radar](https://radar.cloudflare.com/scan) | 看某个网站的技术栈。|  | 维护中|
 | [wr.do](https://github.com/oiov/wr.do) | 基于 Cloudflare 的多租户 DNS 分发系统。开源且免费提供 DNS 解析、短链接生成。| https://wr.do  | 维护中|
 | [cloudflare-proxy-sites](https://github.com/seadfeng/cloudflare-proxy-sites) | Cloudflare Workers web proxy 二级域名访问方式。 | [Demo 地址](https://www.proxysites.ai.serp.ing/) | 维护中 |
-
+| [web-archive](https://github.com/Ray-D-Song/web-archive) | 基于 Cloudflare 的免费网页归档和分享工具。包含一个浏览器插件和运行在 Cloudflare page 上的服务 | https://github.com/Ray-D-Song/web-archive | 维护中 |
 
 
 


### PR DESCRIPTION
项目地址：https://github.com/Ray-D-Song/web-archive

## Web Archive

![showcase](https://raw.githubusercontent.com/ray-d-song/web-archive/main/docs/imgs/showcase.gif)

Web Archive 是一个网页归档工具，包含以下几个部分：

- 浏览器插件：将网页保存为单个 html 文件，并上传到服务端。
- 服务端：   接收浏览器插件上传的快照，并存储在数据库和存储桶中。
- web 客户端： 查询快照并展示。

服务端基于 Cloudflare Worker 的全套服务，包含 D1 数据库、R2 存储桶，**支持一键部署**。  
赛博菩萨 Cloudflare 每个月有 10Gb 的对象存储空间，无限量的传输带宽，数据库 500 万次读，10 万次写，足够负担这样一个 fullstack 应用。

## why
大多数网页归档工具，比如 archivebox，都是基于服务器调用无头浏览器抓取的方式进行归档。  
这种做法的弊端是 知乎、medium 这种需要登录的网站操作很麻烦，需要配置 token 或 cookie。  
同时无头浏览器对服务器的要求也比较高，大多数都是 nas 用户在使用。  
更重要的是，现在流行的 AI 网页翻译工具，比如沉浸式翻译，使用服务端抓取就无法调用。  

web-archive 是一个完全免费、无门槛的方案，而且 Cloudflare 可以非常方便的将数据迁移回本地转为 self-host。

## feat
1. 文件夹分类
2. 页面预览图
3. 标题关键字查询
4. 橱窗，可以分享自己抓取的页面
5. 移动端适配

我的橱窗：https://web-archive-egm.pages.dev/#/showcase/folder