### PR TITLE
feat: Add ip-check project

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -120,6 +120,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | --- | --- | --- | --- |
 | [CloudflareSpeedTest](https://github.com/XIU2/CloudflareSpeedTest) | Viele ausländische Websites verwenden Cloudflare CDN, aber die für Besucher aus dem chinesischen Festland zugewiesenen IPs sind nicht benutzerfreundlich (hohe Latenz, viele Paketverluste, langsame Geschwindigkeit). Obwohl Cloudflare alle IP-Bereiche veröffentlicht hat, ist es mühsam, die passende IP aus so vielen herauszufinden, daher gibt es diese Software. | | Wird gewartet |
 | [SpeedTest](https://speed.cloudflare.com/) | Offizielles SpeedTest-Tool. | | Läuft |
+| [ip-check](https://github.com/lovegitgit/ip-check) | Ein Python-basiertes Cloudflare-CDN-Geschwindigkeitstest-Tool, das mehrere Arten der IP-Eingabe unterstützt (Textdateien, IPv4/IPv6, Ports, bevorzugte Domains usw.), benutzerdefinierte Ports sowie Filterung nach IP-Standort und IP-Organisationsname. | | Wird gewartet |
 
 ## Ueberwachung
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -148,6 +148,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | --- | --- | --- |--- |
 | [CloudflareSpeedTest](https://github.com/XIU2/CloudflareSpeedTest) |Many foreign websites use Cloudflare CDN, but the IPs allocated to visitors from mainland China are not friendly (high latency, packet loss, slow speed). Although Cloudflare has publicly released all IP ranges, it's daunting to find the right one among so many IPs, so this software was created. | | Maintaining |
 | [SpeedTest](https://speed.cloudflare.com/) |Official SpeedTest tool. | | Active |
+| [ip-check](https://github.com/lovegitgit/ip-check) |A Python-based Cloudflare CDN speed testing tool that supports multiple ways of inputting IPs (text files, IPv4/IPv6, ports, preferred domains, etc.), customizable ports, IP geolocation filtering, and IP organization name filtering. | | Maintaining |
 
 ## Monitoring
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -149,6 +149,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | --- | --- | --- | --- |
 | [CloudflareSpeedTest](https://github.com/XIU2/CloudflareSpeedTest) | Muchos sitios web internacionales utilizan Cloudflare CDN, pero las IP asignadas a los visitantes del interior de China no son amigables (alta latencia, muchas pérdidas de paquetes, velocidad lenta). Aunque Cloudflare ha publicado todos los rangos de IP, encontrar uno que se adapte a ti entre tantos puede ser agotador, por lo que se creó este software. |  | En mantenimiento |
 | [SpeedTest](https://speed.cloudflare.com/) | Herramienta oficial de SpeedTest. |  | En funcionamiento |
+| [ip-check](https://github.com/lovegitgit/ip-check) | Una herramienta de prueba de velocidad de CDN de Cloudflare basada en Python que admite múltiples formas de ingresar IPs (archivos de texto, IPv4/IPv6, puertos, dominios preferidos, etc.), puertos personalizables, filtrado por ubicación geográfica de IP y filtrado por nombre de organización de IP. | | En mantenimiento |
 
 ## Monitoreo
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 | --- | --- | --- |--- |
 | [CloudflareSpeedTest](https://github.com/XIU2/CloudflareSpeedTest) |国外很多网站都在使用 Cloudflare CDN，但分配给中国内地访客的 IP 并不友好（延迟高、丢包多、速度慢）。虽然 Cloudflare 公开了所有 IP 段 ，但想要在这么多 IP 中找到适合自己的，怕是要累死，于是就有了这个软件。 | |维护中|
 | [SpeedTest](https://speed.cloudflare.com/) |官方的SpeedTest工具。 | |运行中|
+| [ip-check](https://github.com/lovegitgit/ip-check) |Python 实现的Cloudflare CDN 测速工具，支持多种方式传入ip（文本、ipv4/ipv6、端口、优选域名等）、自定义端口、ip 归属地筛选、ip 组织名筛选等。 | |维护中|
 
 ## 监控
 


### PR DESCRIPTION
添加了 ip-check 项目:

基于Python 实现的Cloudflare CDN 测速工具，支持多种方式传入ip（文本、ipv4/ipv6、端口、优选域名等）、自定义端口、ip 归属地筛选、ip 组织名筛选等。
已添加中文、英文、西班牙文和德文版本的说明