### PR TITLE
docs: 新增 Cloudflare Worker + Hono + Telegram Bot API 構建 RSS 訂閱推送系統文章

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -145,6 +145,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [Kostenlose CAPTCHA-Alternative](https://www.cloudflare.com/zh-cn/products/turnstile/) | Offizielles Produkt, kostenlose CAPTCHA-Alternative. | | Aktiv |
 | [Nachrichten an Telegram über Cloudflare Page Functions senden](https://liujiacai.net/blog/2024/05/07/telegram-bot-functions/) | Dieser Artikel erklärt, wie man Seitenfunktionen als GitHub- | | Aktiv |
 | [Erstellen einer Blog-AI-Zusammenfassung mit Cloudflare Workers](https://mabbs.github.io/2024/07/03/ai-summary.html) | Einführung der Blog-AI-Zusammenfassung mithilfe der Cloudflare Workers+Workers AI+D1-Datenbank.| | Aktiv |
+| [RSS-Abonnement-Push-System mit Cloudflare Worker, Hono und Telegram Bot API bauen](https://calpa.me/blog/build-rss-subscription-push-system-with-cloudflare-worker-hono-telegram-bot-api/) | Ausführliche Anleitung zum Einsatz von Cloudflare Worker, Hono Framework und Telegram Bot API, um ein serverloses System zu bauen, das RSS-Feeds überwacht und Updates an Telegram-Kanäle pusht. Vollständig serverlos, geeignet für Einzelentwickler und kleine Teams, unterstützt geplante Aufgaben und Duplikatvermeidung. | |Aktiv|
 
 ## Sonstiges
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -173,6 +173,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [Free CAPTCHA Alternative](https://www.cloudflare.com/zh-cn/products/turnstile/) |Officially produced, free CAPTCHA alternative. | | Active |
 | [Sending Messages to Telegram via Cloudflare Page Functions](https://liujiacai.net/blog/2024/05/07/telegram-bot-functions/) | This article introduces how to utilize page functions as GitHub webhook addresses to forward specific events to Telegram channels. | | Active |
 | [Using Cloudflare Workers to create AI blog summaries](https://mabbs.github.io/2024/07/03/ai-summary.html) | Introduce the implementation of blog AI summarization using Cloudflare Workers + Workers AI + D1 database.| | Active |
+| [Build an RSS Subscription Push System with Cloudflare Worker, Hono, and Telegram Bot API](https://calpa.me/blog/build-rss-subscription-push-system-with-cloudflare-worker-hono-telegram-bot-api/) | A detailed guide on using Cloudflare Worker, Hono framework, and Telegram Bot API to build a serverless system that monitors RSS feeds and pushes updates to Telegram channels. Fully serverless, suitable for individual developers and small teams, supports scheduled tasks and duplicate message prevention. | |Active|
 
 ## Others
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -174,6 +174,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [Alternativa gratuita a CAPTCHA](https://www.cloudflare.com/zh-cn/products/turnstile/) | Producto oficial, una alternativa gratuita a CAPTCHA. |  | Activo |
 | [Enviando mensajes a Telegram a través de las funciones de página de Cloudflare](https://liujiacai.net/blog/2024/05/07/telegram-bot-functions/) | Este artículo presenta cómo utilizar funciones de página como direcciones de webhook de GitHub para reenviar eventos específicos a canales de Telegram. | | Activo |
 | [Hacer un resumen de la IA del blog con cloudflare Workers](https://mabbs.github.io/2024/07/03/ai-summary.html) | Introduce el uso de la base de datos cloudflare Workers + Workers Ai + D1 para implementar el resumen de Ia del blog.| | Activo |
+| [Construir un sistema de suscripción y push RSS con Cloudflare Worker, Hono y Telegram Bot API](https://calpa.me/blog/build-rss-subscription-push-system-with-cloudflare-worker-hono-telegram-bot-api/) | Guía detallada sobre cómo usar Cloudflare Worker, el framework Hono y la API de Telegram Bot para crear un sistema serverless que monitorea fuentes RSS y envía actualizaciones a canales de Telegram. Totalmente sin servidor, ideal para desarrolladores individuales y pequeños equipos, soporta tareas programadas y evita mensajes duplicados. | |Activo|
 
 ## Otros
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,7 @@
 | [使用Cloudflare Workers制作博客AI摘要](https://mabbs.github.io/2024/07/03/ai-summary.html) | 介绍使用Cloudflare Workers + Workers AI + D1数据库实现博客AI摘要。| |有效中|
 | [使用CF Workers Cron触发器进行签到](https://mabbs.github.io/2023/02/22/cron.html) | 这篇文章讲述了作者在云原神签到脚本被Github Actions禁用后，选择使用Cloudflare Workers Cron触发器的原因。| |有效中|
 | [用Workers免服务器部署挪车二维码，可微信通知、拨打电话](https://www.dujin.org/23105.html) | 基于微信推送实现消息通知。| |有效中|
-
-
+| [使用 Cloudflare Worker、Hono 和 Telegram Bot API 构建 RSS 订阅推送系统](https://calpa.me/blog/build-rss-subscription-push-system-with-cloudflare-worker-hono-telegram-bot-api/) | 本文详细介绍如何利用 Cloudflare Worker、Hono 框架和 Telegram Bot API 构建一个自动监控 RSS 订阅源并推送更新到 Telegram 频道的系统。该方案完全 Serverless，无需服务器，适合个人开发者和小型团队，支持定时任务和消息去重。| |有效中|
 
 ## 其他
 


### PR DESCRIPTION
## 內容簡介

本 PR 新增一篇技術文章：**《使用 Cloudflare Worker、Hono 和 Telegram Bot API 構建 RSS 訂閱推送系統》**，已同步更新至中文、英文、西班牙文和德文版本的 README。

### 文章亮點
- 詳細介紹如何利用 Cloudflare Worker、Hono 框架與 Telegram Bot API，打造一個自動監控 RSS 訂閱源並推送更新到 Telegram 頻道的 Serverless 系統。
- 完整涵蓋開發環境準備、專案設置、RSS 解析、Telegram 整合、去重存儲、Hono 應用構建、Cloudflare 部署與自動化、手動測試、故障排除與進階優化方法。
- 提供多個進階擴展建議（如多 RSS 支援、自定義格式、錯誤通知等）。
- 文章原文與完整代碼已開源於 [calpa/rss-to-telegram](https://github.com/calpa/rss-to-telegram)。

### 主要技術棧
- Cloudflare Worker
- Hono 框架
- Telegram Bot API
- TypeScript / Node.js
- Cloudflare KV / Cron Trigger

### 適用對象
- 個人開發者、小型團隊、希望無伺服器自動化內容推送的用戶。

---

詳細內容請參考原文：[使用 Cloudflare Worker、Hono 和 Telegram Bot API 構建 RSS 訂閱推送系統 - Calpa 的技術博客](https://calpa.me/blog/build-rss-subscription-push-system-with-cloudflare-worker-hono-telegram-bot-api/)

如有任何建議或問題，歡迎討論與交流！