### PR TITLE
Add deploy-mcp to monitoring sections across all languages

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -130,6 +130,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [UptimeFlare](https://github.com/lyc8503/UptimeFlare) | Ein serverloses Website-Überwachungstool basierend auf Cloudflare Worker. Es unterstützt die Überwachung von Ports für mehrere Protokolle, einschließlich HTTP/HTTPS/TCP. Es kann geografisch spezifische Überprüfungen aus Hunderten von Städten weltweit durchführen, mit anpassbaren Anforderungsparametern und Regeln zur Validierung der Antwort, anpassbar für verschiedene Überwachungsszenarien. | <https://uptimeflare.pages.dev/>| In Wartung |
 | [cf-workers-status-page](https://github.com/eidam/cf-workers-status-page) | Überwachen Sie Ihre Website, zeigen Sie den Status (einschließlich täglicher Historie) an und erhalten Sie Slack-Benachrichtigungen, wenn sich der Status der Website ändert. Verwendet Cloudflare Workers, CRON-Auslöser und KV-Speicher. | <https://status-page.eidam.dev/> | In Wartung |
 | [xugou](https://github.com/zaunist/xugou)| Ein auf CloudFlare basierendes Website- und Server-Überwachungstool. | https://xugou.mdzz.uk/ | In Wartung |
+| [deploy-mcp](https://github.com/alexpota/deploy-mcp) | Universeller Deployment-Tracker für KI-Assistenten mit Live-Status-Badges und Deployment-Überwachung, einschließlich Cloudflare Pages-Unterstützung. | https://deploy-mcp.io | Aktiv |
 
 ## Artikel
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -158,6 +158,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [UptimeFlare](https://github.com/lyc8503/UptimeFlare) | A serverless website monitoring tool based on Cloudflare Worker. It supports monitoring ports for multiple protocols including HTTP/HTTPS/TCP. It can initiate geographically specific checks from hundreds of cities worldwide, with customizable request parameters and response validation rules, adaptable for various monitoring scenarios. | <https://uptimeflare.pages.dev/> | Under maintenance |
 | [cf-workers-status-page](https://github.com/eidam/cf-workers-status-page) | Monitor your website, display status (including daily history), and receive Slack notifications when the website status changes. Utilizes Cloudflare Workers, CRON triggers, and KV storage. | <https://status-page.eidam.dev/> | Under maintenance |
 | [xugou](https://github.com/zaunist/xugou)| A website monitoring and server monitoring tool based on CloudFlare. | https://xugou.mdzz.uk/ |  Under maintenance |
+| [deploy-mcp](https://github.com/alexpota/deploy-mcp) | Universal deployment tracker for AI assistants with live status badges and deployment monitoring, including Cloudflare Pages support. | https://deploy-mcp.io | Active |
 
 ## Articles
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -159,6 +159,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [UptimeFlare](https://github.com/lyc8503/UptimeFlare) | Una herramienta de monitoreo de sitios web sin servidor basada en Cloudflare Worker. Admite monitoreo de puertos para múltiples protocolos, incluidos HTTP/HTTPS/TCP. Puede iniciar comprobaciones geográficamente específicas desde cientos de ciudades en todo el mundo, con parámetros de solicitud personalizables y reglas de validación de respuesta, adaptable para diversos escenarios de monitoreo. | <https://uptimeflare.pages.dev/> | En mantenimiento |
 | [cf-workers-status-page](https://github.com/eidam/cf-workers-status-page) | Monitorea tu sitio web, muestra el estado (incluido el historial diario) y recibe notificaciones de Slack cuando cambia el estado del sitio web. Utiliza Cloudflare Workers, disparadores CRON y almacenamiento KV. | <https://status-page.eidam.dev/> | En mantenimiento |
 | [xugou](https://github.com/zaunist/xugou)| Una herramienta de monitoreo de sitios web y servidores basada en CloudFlare. | https://xugou.mdzz.uk/ |  En mantenimiento |
+| [deploy-mcp](https://github.com/alexpota/deploy-mcp) | Rastreador universal de despliegues para asistentes de IA con insignias de estado en vivo y monitoreo de despliegues, incluyendo soporte para Cloudflare Pages. | https://deploy-mcp.io | Activo |
 
 ## Artículos
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 | [cf-workers-status-page](https://github.com/eidam/cf-workers-status-page) |监控您的网站，展示状态（包括每日历史记录），并在网站状态发生变化时收到 Slack 通知。使用 Cloudflare Workers、CRON 触发器和 KV 存储。 | <https://status-page.eidam.dev/> |维护中|
 | [xugou](https://github.com/zaunist/xugou)| 基于 CloudFlare 的站点监控以及服务器监控工具。 | https://xugou.mdzz.uk/ |  维护中
 | [cf-vps-monitor](https://github.com/kadidalax/cf-vps-monitor)| 一个部署在 Cloudflare Workers 上的简单 VPS 监控 + 网站监测 面板，使用 Cloudflare D1 数据库存储数据。 | <https://vps-monitor.abo-vendor289.workers.dev/> |  维护中
+| [deploy-mcp](https://github.com/alexpota/deploy-mcp) | 为AI助手提供的通用部署跟踪器，支持实时状态徽章和部署监控，包括对 Cloudflare Pages 的支持。 | https://deploy-mcp.io | 有效中 |
 
 # 文章
 


### PR DESCRIPTION
Added deploy-mcp - universal deployment tracker for AI assistants with live status badges and deployment monitoring, including Cloudflare Pages support.

Updated files:
- README-EN.md (English)
- README.md (Chinese)
- README-ES.md (Spanish)
- README-DE.md (German)

All descriptions focus on universal deployment tracking while highlighting Cloudflare Pages support to respect the repository's focus.

## Technical Rationale

  - **Category Alignment**: deploy-mcp belongs in the monitoring section as it tracks deployment states and provides status reporting
  - **Cloudflare Pages Integration**: Implements webhook endpoints for real-time deployment state updates and badge generation
  - **MCP Protocol**: Provides Model Context Protocol tools for programmatic access to deployment data
  - **Production Status**: Active service with documented API at deploy-mcp.io

  ## Implementation Details

  - Webhook-driven real-time deployment state tracking
  - HTTP badge endpoints for status visualization
  - MCP server implementation for AI assistant integration
  - Multi-language documentation maintained across all README versions

  ## Repository Impact

  - Adds one entry per language version (4 total additions)
  - Maintains existing table structure and formatting
  - Uses consistent description pattern across languages