### PR TITLE
docs: add gemini-balance-do project

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -106,6 +106,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [cloudflare-docker-proxy](https://github.com/ciiiii/cloudflare-docker-proxy) | Ein Projekt namens cloudflare-docker-proxy, das ein Docker Hub-Registry-Proxy ist, das auf Cloudflare Worker läuft. |  | In Wartung |
 | [CF-Workers-docker.io](https://github.com/cmliu/CF-Workers-docker.io) | Dieses Projekt ist ein auf Cloudflare Workers basierendes Docker-Image-Proxy-Tool. Es kann Anfragen an das offizielle Docker-Image-Repository weiterleiten, Zugriffsrestriktionen lösen und den Zugriff beschleunigen. | <https://docker.fxxk.dedyn.io/> | In Wartung |
 | [cf-workers-proxy](https://github.com/jonssonyan/cf-workers-proxy) | Der HTTP-Reverse-Proxy von Cloudflare Workers unterstützt theoretisch das Proxying aller blockierten Domänennamen. Sie müssen lediglich die Umgebungsvariable PROXY_HOSTNAME auf den blockierten Domänennamen setzen. |  | In Wartung |
+| [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | Basierend auf Cloudflare Worker und Durable Objects implementiert dieses Projekt ein Gemini-API-Relay (Multi-Key-Lastenausgleich) für stabilen US-IP-Zugriff auf Gemini. | https://github.com/zaunist/gemini-balance-do | Wird gewartet |
 
 ## Dateifreigabe
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -134,6 +134,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [cloudflare-docker-proxy](https://github.com/ciiiii/cloudflare-docker-proxy) | A project named cloudflare-docker-proxy, which is a Docker Hub registry proxy running on Cloudflare Worker. |  | Maintaining |
 | [CF-Workers-docker.io](https://github.com/cmliu/CF-Workers-docker.io) | This project is a Docker image proxy tool based on Cloudflare Workers. It can relay requests to the official Docker image repository, solving access restrictions and accelerating access. | <https://docker.fxxk.dedyn.io/> | Maintaining |
 | [cf-workers-proxy](https://github.com/jonssonyan/cf-workers-proxy) | Cloudflare Workers HTTP reverse proxy, theoretically supports proxying any blocked domain name, just set the environment variable PROXY_HOSTNAME to the blocked domain name |  | Maintaining |
+| [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | Based on Cloudflare Worker and Durable Objects, this project implements a Gemini API relay (multi-key load balancing) for stable US IP access to Gemini. | https://github.com/zaunist/gemini-balance-do | Maintained |
 
 ## File Sharing
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -135,6 +135,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [cloudflare-docker-proxy](https://github.com/ciiiii/cloudflare-docker-proxy) | Un proyecto llamado cloudflare-docker-proxy, que es un proxy de registro de Docker Hub que se ejecuta en Cloudflare Worker. |  | En mantenimiento |
 | [CF-Workers-docker.io](https://github.com/cmliu/CF-Workers-docker.io) | Este proyecto es una herramienta de proxy de imagen de Docker basada en Cloudflare Workers. Puede retransmitir solicitudes al repositorio oficial de imágenes de Docker, resolviendo restricciones de acceso y acelerando el acceso. | <https://docker.fxxk.dedyn.io/> | En mantenimiento |
 | [cf-workers-proxy](https://github.com/jonssonyan/cf-workers-proxy) | En teoría, el proxy inverso HTTP de Cloudflare Workers admite la transferencia de cualquier nombre de dominio bloqueado. Solo necesita configurar la variable de entorno PROXY_HOSTNAME en el nombre de dominio bloqueado. |  | En mantenimiento |
+| [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | Basado en Cloudflare Worker y Durable Objects, este proyecto implementa un relé de API de Gemini (equilibrio de carga de múltiples claves) para un acceso estable con IP de EE. UU. a Gemini. | https://github.com/zaunist/gemini-balance-do | Mantenido |
 
 ## Compartir archivos
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@
 | [CF-Workers-docker.io](https://github.com/cmliu/CF-Workers-docker.io) |这个项目是一个基于 Cloudflare Workers 的 Docker 镜像代理工具。它能够中转对 Docker 官方镜像仓库的请求，解决一些访问限制和加速访问的问题. | <https://docker.fxxk.dedyn.io/> |维护中|
 | [Page-api-forwarder](https://github.com/xinjianzhanghao/page-api-forwarder) | 它可以帮助您绕过某些API上的IP限制，并且由于它通过Cloudflare，因此速度很快。 |  |维护中|
 | [AI-worker](https://github.com/qyjoy/AI-worker) | 通过Cloudflare免费、私有化访问和管理Gemini~摆脱地域限制无烦恼，完全由自己掌控。 |  |维护中|
-
+| [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | 基于 Cloudflare Worker 和 Durable Objects 实现的 Gemini API 中转（多key负载均衡），稳定美国 IP 访问 Gemini | https://github.com/zaunist/gemini-balance-do | 维护中 |
 
 
 ## 文件分享


### PR DESCRIPTION
Gemini-Balance-DO 是一个部署在 Cloudflare Workers 上的 Gemini API 负载均衡器和代理服务，使用了 Durable Objects 来存储和管理 API 密钥，无论你连接的 worker 节点在属于哪个地区，最后都会转发到美国以后再向 Gemini 发起请求，不用再担心地区不支持的问题！