### PR TITLE
docs: add subpool-worker project

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -179,6 +179,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [melody-auth](https://github.com/ValueMelody/melody-auth) | Ein OAuth- und Authentifizierungssystem basierend auf Cloudflare Workers, D1 und KV. | <https://auth.valuemelody.com/> | Aktiv |
 | [Cloudflare-KV-Manager](https://github.com/som3canadian/Cloudflare-KV-Manager) | Das fehlende Tool für Ihre Cloudflare KV. Eine vollständigere und einfachere Lösung zum Verwalten von Cloudflare KV-Speicher. Enthält eine Weboberfläche und eine kleine Python-Bibliothek. | <https://kv-demo.somecanadian.com> | Aktiv |
 | [CF-TOOLS](https://github.com/MainPoser/cf-tools) | Integrieren Sie gängige Entwicklungstools, KI-Assistenten usw. | <https://cf-tools.tianyao.qzz.io/> | Wird aktualisiert |
+| [subpool-worker](https://github.com/illusionlie/subpool-worker) | Leichtgewichtiger Abonnement-Pool-Dienst zum Verwalten und Verteilen von Proxy-Abonnement-Links. |  | Aktiv gepflegt |
 
 ## Tutorials
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -207,6 +207,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [melody-auth](https://github.com/ValueMelody/melody-auth) | An oauth and authentication system based on Cloudflare workers, D1 and KV. | <https://auth.valuemelody.com/> | Active |
 | [Cloudflare-KV-Manager](https://github.com/som3canadian/Cloudflare-KV-Manager) | The missing tool for your Cloudflare KV. A more complete and simple solution for managing Cloudflare KV storage. Include a web interface and a small python lib. | <https://kv-demo.somecanadian.com> | Active |
 | [CF-TOOLS](https://github.com/MainPoser/cf-tools) | Integrate commonly used development tools, AI assistants, etc. | <https://cf-tools.tianyao.qzz.io/> | Updating |
+| [subpool-worker](https://github.com/illusionlie/subpool-worker) | Lightweight subscription pool service for managing and distributing proxy subscription links. | | Actively Maintained |
 
 ## Tutorials
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -208,6 +208,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [melody-auth](https://github.com/ValueMelody/melody-auth) | Un sistema de autenticación y oauth basado en Cloudflare workers, D1 y KV. | <https://auth.valuemelody.com/> | Activo |
 | [Cloudflare-KV-Manager](https://github.com/som3canadian/Cloudflare-KV-Manager) | La herramienta que falta para tu Cloudflare KV. Una solución más completa y sencilla para gestionar el almacenamiento de Cloudflare KV. Incluye una interfaz web y una pequeña biblioteca de Python. | <https://kv-demo.somecanadian.com> | Activo |
 | [CF-TOOLS](https://github.com/MainPoser/cf-tools) | Integrigi oftajn programadilon kaj AI-asistantojn. | <https://cf-tools.tianyao.qzz.io/> | Actualizando |
+| [subpool-worker](https://github.com/illusionlie/subpool-worker) | Servicio ligero para la gestión y distribución de suscripciones proxy. |  | Mantenido activamente |
 
 ## Tutoriales
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@
 | [Text2img-Cloudflare-Workers](https://github.com/huarzone/Text2img-Cloudflare-Workers) | 一个基于 Cloudflare AI & Workers 的在线文生图服务✨ | <https://text2img.huarzone.com/> | 有效中 |
 | [Edgebin](https://github.com/jiacai2050/edgebin) | 类似与 httpbin 的 HTTP 测试服务 | <https://edgebin.liujiacai.net> | 有效中 |
 | [CF-TOOLS](https://github.com/MainPoser/cf-tools) | 整合常用开发工具，AI 助手等。 | <https://cf-tools.tianyao.qzz.io/> | 有效中 |
+| [subpool-worker](https://github.com/illusionlie/subpool-worker) | 轻量级订阅池服务，用于管理和分发代理订阅链接 |  | 维护中 |
 
 
 


### PR DESCRIPTION
subpool-worker 是一个基于 Cloudflare Workers 的轻量级订阅池服务，用于管理和分发代理订阅链接。
项目地址: <https://github.com/illusionlie/subpool-worker>