### PR TITLE
Add What Broke Today to monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 | [xugou](https://github.com/zaunist/xugou)| 基于 CloudFlare 的站点监控以及服务器监控工具。 | https://xugou.mdzz.uk/ |  维护中
 | [cf-vps-monitor](https://github.com/kadidalax/cf-vps-monitor)| 一个部署在 Cloudflare Workers 上的简单 VPS 监控 + 网站监测 面板，使用 Cloudflare D1 数据库存储数据。 | <https://vps-monitor.abo-vendor289.workers.dev/> |  维护中
 | [deploy-mcp](https://github.com/alexpota/deploy-mcp) | 为AI助手提供的通用部署跟踪器，支持实时状态徽章和部署监控，包括对 Cloudflare Pages 的支持。 | https://deploy-mcp.io | 有效中 |
+| [What Broke Today](https://whatbroke.today/) | AI 驱动的宕机聚合器，追踪 100+ 云服务（包括 Cloudflare）的状态，提供实时 Telegram 警报、RSS 订阅和 JSON API。 | <https://whatbroke.today/> | 维护中 |
 
 # 文章
 


### PR DESCRIPTION
## Summary

Adding [What Broke Today](https://whatbroke.today/) to the monitoring (监控) section.

**What Broke Today** is an AI-powered outage aggregator that:
- Monitors 100+ cloud services including Cloudflare status
- Uses AI to filter and summarize service outages
- Provides real-time Telegram alerts
- Offers RSS feed and JSON API

**Website**: https://whatbroke.today
**Source Code**: https://github.com/reshadat/whatbroketoday

---

在监控部分添加 What Broke Today。

What Broke Today 是一个 AI 驱动的宕机聚合器，追踪 100+ 云服务（包括 Cloudflare）的状态，提供实时 Telegram 警报、RSS 订阅和 JSON API。