### PR TITLE
Add ShotOG — edge-native OG image generation API

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -193,6 +193,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [whisper_cloudflare](https://github.com/thun888/whisper_cloudflare) | Online-Audio-Transkriptionstool basierend auf Whisper-Modell, auf Cloudflare bereitgestellt. Konvertiert Audiodateien in Text und unterstützt SRT-Untertitelgenerierung. | | Wird gewartet |
 | [micro-notepad](https://github.com/thun888/micro-notepad/) | Mini-Notizblock, Cloudflare-Worker-Implementierung von [pereorga/minimalist-web-notepad](https://github.com/pereorga/minimalist-web-notepad). | | Wird gewartet |
 | [cf-page-publish-mcp](https://github.com/Actrue/cf-page-publish-mcp) | Cloudflare-Seitenveröffentlichungs-MCP-Tool, das HTML-Seiten auf Cloudflare Workers veröffentlichen kann. Kann über MCP mit KI verbinden. | | Wird gewartet |
+| [ShotOG](https://github.com/nicepkg/shotog) | Edge-native OG-Bildgenerierungs-API auf Workers + D1. 8 integrierte Vorlagen, anpassbare Titel/Untertitel/Autor-Parameter, ~50ms Edge-Rendering ohne Puppeteer. | <https://shotog.2214962083.workers.dev> | Wird gewartet |
 
 
 ## Tutorials

--- a/README-EN.md
+++ b/README-EN.md
@@ -222,6 +222,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [whisper_cloudflare](https://github.com/thun888/whisper_cloudflare) | Online audio transcription tool based on Whisper model, deployed on Cloudflare. Converts audio files to text and supports SRT subtitle generation. | | Maintaining |
 | [micro-notepad](https://github.com/thun888/micro-notepad/) | Mini notepad, Cloudflare Worker implementation of [pereorga/minimalist-web-notepad](https://github.com/pereorga/minimalist-web-notepad). | | Maintaining |
 | [cf-page-publish-mcp](https://github.com/Actrue/cf-page-publish-mcp) | Cloudflare page publishing mcp tool that can publish HTML pages to Cloudflare Workers. Can connect to AI via MCP. | | Maintaining |
+| [ShotOG](https://github.com/nicepkg/shotog) | Edge-native OG image generation API built on Workers + D1. 8 built-in templates, customizable title/subtitle/author params, ~50ms edge rendering without Puppeteer. | <https://shotog.2214962083.workers.dev> | Maintaining |
 
 
 ## Tutorials

--- a/README-ES.md
+++ b/README-ES.md
@@ -222,6 +222,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [whisper_cloudflare](https://github.com/thun888/whisper_cloudflare) | Herramienta de transcripción de audio en línea basada en el modelo Whisper, desplegada en Cloudflare. Convierte archivos de audio a texto y soporta generación de subtítulos SRT. | | En mantenimiento |
 | [micro-notepad](https://github.com/thun888/micro-notepad/) | Mini bloc de notas, implementación de Cloudflare Worker de [pereorga/minimalist-web-notepad](https://github.com/pereorga/minimalist-web-notepad). | | En mantenimiento |
 | [cf-page-publish-mcp](https://github.com/Actrue/cf-page-publish-mcp) | Herramienta MCP de publicación de páginas Cloudflare que puede publicar páginas HTML en Cloudflare Workers. Puede conectarse a IA a través de MCP. | | En mantenimiento |
+| [ShotOG](https://github.com/nicepkg/shotog) | API de generación de imágenes OG nativa del edge con Workers + D1. 8 plantillas integradas, parámetros personalizables de título/subtítulo/autor, renderizado en ~50ms sin Puppeteer. | <https://shotog.2214962083.workers.dev> | En mantenimiento |
 
 
 ## Tutoriales

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@
 | [whisper_cloudflare](https://github.com/thun888/whisper_cloudflare) | 基于 Whisper 模型的在线音频转写工具，部署在 Cloudflare 上。可以将音频文件转换为文字，并支持生成 SRT 格式的字幕文件。| | 维护中 |
 | [micro-notepad](https://github.com/thun888/micro-notepad/) | 迷你笔记本，对 [pereorga/minimalist-web-notepad](https://github.com/pereorga/minimalist-web-notepad) 的cloudflare worker实现。| | 维护中 |
 | [cf-page-publish-mcp](https://github.com/Actrue/cf-page-publish-mcp) | cloudflare 页面发布 mcp 工具，可以将 html 页面发布到 cloudflare，worker 上。可以mcp对接ai。| | 维护中 |
+| [ShotOG](https://github.com/nicepkg/shotog) | 基于 Cloudflare Workers + D1 的 OG 图片生成 API，内置 8 个模板，支持自定义标题/副标题/作者等参数，边缘渲染无需 Puppeteer，响应速度 ~50ms。| <https://shotog.2214962083.workers.dev> | 维护中 |
 
 ## 教程
 


### PR DESCRIPTION
## What is ShotOG?

[ShotOG](https://github.com/nicepkg/shotog) is an OG image generation API built entirely on Cloudflare Workers + D1.

**Features:**
- 8 built-in templates (blog, product, social, event, changelog, testimonial, announcement, basic)
- Customizable title, subtitle, author, and theme parameters
- ~50ms edge rendering using Satori + resvg-wasm (no Puppeteer/headless browser)
- Built-in caching via Cache API
- API key management with usage tracking
- TypeScript SDK available

**Live demo:** https://shotog.2214962083.workers.dev
**GitHub:** https://github.com/nicepkg/shotog

## Changes

Added ShotOG to the "其他" (Other) section in all 4 README files (CN, EN, DE, ES).

## Why it fits this list

- 100% runs on Cloudflare Workers + D1
- Open source (MIT license)
- Useful for indie developers who need OG images without running their own infrastructure
- Actively maintained