### PR TITLE
添加 Webhook Debugger - 自托管 Webhook 调试工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
   - [文件分享](#文件分享)
   - [测速](#测速)
   - [监控](#监控)
+  - [开发者工具](#开发者工具)
 - [文章](#文章)
   - [其他](#其他)
   - [教程](#教程)
@@ -196,6 +197,12 @@
 | [cf-vps-monitor](https://github.com/kadidalax/cf-vps-monitor)| 一个部署在 Cloudflare Workers 上的简单 VPS 监控 + 网站监测 面板，使用 Cloudflare D1 数据库存储数据。 | <https://vps-monitor.abo-vendor289.workers.dev/> |  维护中
 | [deploy-mcp](https://github.com/alexpota/deploy-mcp) | 为AI助手提供的通用部署跟踪器，支持实时状态徽章和部署监控，包括对 Cloudflare Pages 的支持。 | https://deploy-mcp.io | 有效中 |
 | [What Broke Today](https://whatbroke.today/) | AI 驱动的宕机聚合器，追踪 100+ 云服务（包括 Cloudflare）的状态，提供实时 Telegram 警报、RSS 订阅和 JSON API。 | <https://whatbroke.today/> | 维护中 |
+
+## 开发者工具
+
+| 名称 | 特性 |在线地址 | 状态|
+| --- | --- | --- |--- |
+| [Webhook Debugger](https://github.com/brancogao/webhook-debugger) | 自托管 Webhook 调试工具，支持签名验证（Stripe/GitHub/Slack/Shopify）、90天历史、全文搜索、一键重放。基于 Cloudflare Workers + D1 构建。 | <https://webhook-debugger.autocompany.workers.dev> | 维护中 |
 
 # 文章
 


### PR DESCRIPTION
## 摘要

新增"开发者工具"分类，并收录 [Webhook Debugger](https://github.com/brancogao/webhook-debugger)。

### Webhook Debugger 特性
- **签名验证** - 验证 Webhook 是否来自 Stripe、GitHub、Slack、Shopify 等真实来源
- **90天历史** - 完整的 Webhook 历史记录，支持全文搜索
- **一键重放** - 将 Webhook 转发到任意 URL 进行调试
- **自托管** - 部署到自己的 Cloudflare 账户，数据完全可控
- **免费友好** - 基于 Cloudflare Workers + D1，免费套餐足够个人使用

### 为什么收录
- 填补了 Cloudflare 生态中 Webhook 调试工具的空白
- 帮助独立开发者调试第三方服务集成
- 完全开源（MIT 许可证）

### 链接
- 源码：https://github.com/brancogao/webhook-debugger
- 演示：https://webhook-debugger.autocompany.workers.dev