### PR TITLE
添加 SSL Certificate Monitor - SSL 证书到期监控工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
 | [cf-workers-status-page](https://github.com/eidam/cf-workers-status-page) |监控您的网站，展示状态（包括每日历史记录），并在网站状态发生变化时收到 Slack 通知。使用 Cloudflare Workers、CRON 触发器和 KV 存储。 | <https://status-page.eidam.dev/> |维护中|
 | [xugou](https://github.com/zaunist/xugou)| 基于 CloudFlare 的站点监控以及服务器监控工具。 | https://xugou.mdzz.uk/ |  维护中
 | [cf-vps-monitor](https://github.com/kadidalax/cf-vps-monitor)| 一个部署在 Cloudflare Workers 上的简单 VPS 监控 + 网站监测 面板，使用 Cloudflare D1 数据库存储数据。 | <https://vps-monitor.abo-vendor289.workers.dev/> |  维护中
+| [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) | SSL 证书到期监控工具，检查 SSL 证书有效期并通过 RESTful API 提供服务。 | <https://ssl-certificate-monitor.autocompany.workers.dev/> |维护中|
 | [deploy-mcp](https://github.com/alexpota/deploy-mcp) | 为AI助手提供的通用部署跟踪器，支持实时状态徽章和部署监控，包括对 Cloudflare Pages 的支持。 | https://deploy-mcp.io | 有效中 |
 | [What Broke Today](https://whatbroke.today/) | AI 驱动的宕机聚合器，追踪 100+ 云服务（包括 Cloudflare）的状态，提供实时 Telegram 警报、RSS 订阅和 JSON API。 | <https://whatbroke.today/> | 维护中 |
 


### PR DESCRIPTION
## Summary
添加 SSL Certificate Monitor - 一个免费的 SSL 证书到期检查和监控工具。

## 功能特性
- 检查 SSL 证书到期日期
- 查看证书详情（颁发者、算法、SANs）
- RESTful API 用于程序化访问
- Web UI 用于手动检查
- 无需注册

## 链接
- Demo: https://ssl-certificate-monitor.autocompany.workers.dev
- GitHub: https://github.com/brancogao/ssl-certificate-monitor

## 技术栈
- Cloudflare Workers
- TypeScript