### PR TITLE
Add PageGuard - 免费网站健康扫描器（Workers + D1 + Workers AI）

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 | [analytics_with_cloudflare](https://github.com/yestool/analytics_with_cloudflare) |免费开源网页访客计数器, Webviso 是一个基于Cloudflare worker服务+Cloudflare D1数据库实现的完全免费的在线web访客统计服务。 功能与目前常用的 不蒜子 - 极简网页计数器 相同。Webviso完全开源，你可以实现自定义需求。 基于Cloudflare的微服务架构可快速自行部署上线。 | <https://webviso.yestool.org/> |维护中|
 | [counterscale](https://github.com/benvinegar/counterscale) |Counterscale 是一个简单的 Web 分析跟踪器和仪表板，效果和 umami 类似，您可以在 Cloudflare 上自行托管。它的设计易于部署和维护，即使在高流量的情况下，您的操作成本也应该接近于零（Cloudflare 的免费套餐假设可以支持每天高达 10 万次点击）。 | <https://counterscale.dev/> |维护中|
 | [HanAnalytics](https://github.com/uxiaohan/HanAnalytics) |一个部署在Cloudflare Pages上的简单的网络分析跟踪器和仪表板，是umami的精简版，它支持设备查看、来源查看、国家地区及设备OS等数据查看分析，支持密码访问，域名白名单等功能。 |  |维护中|
+| [PageGuard](https://github.com/sleepyxpad-jpg/pageguard) |免费网站健康扫描器，基于 Cloudflare Workers + D1 + Workers AI（Llama 3.1）。检查 SEO、性能（Core Web Vitals）、无障碍（WCAG 2.1）、最佳实践，30 秒出 AI 诊断报告，无需注册登录。 | <https://pageguard.qiudeqiu.workers.dev> |维护中|
 
 
 


### PR DESCRIPTION
## PageGuard — 免费网站健康扫描器

**GitHub**: https://github.com/sleepyxpad-jpg/pageguard  
**在线演示**: https://pageguard.qiudeqiu.workers.dev

### 功能

PageGuard 是基于 Cloudflare Workers 构建的免费网站健康扫描器，一键检测：

- SEO（meta标签、结构化数据、Open Graph）
- 性能（Core Web Vitals，通过 Google PageSpeed Insights API）
- 无障碍（WCAG 2.1 合规性）
- 最佳实践（HTTPS、图片格式、废弃 API）
- **AI 诊断报告**（Cloudflare Workers AI / Llama 3.1 8B，输出纯文字行动计划）
- 扫描历史对比（同一域名多次扫描显示分数趋势）

### 技术栈（全部 Cloudflare）

- **Cloudflare Workers** — 计算层
- **Cloudflare D1** — 扫描历史缓存（边缘 SQLite）
- **Cloudflare Workers AI** — Llama 3.1 8B 生成报告

### 成本

0-1000 用户/天：**$0**（全程免费套餐）

无需注册、无需登录，直接输入 URL 即可扫描。添加到"网站分析"分类。