### PR TITLE
Add LLMKit - AI API gateway on CF Workers + Durable Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 | [Page-api-forwarder](https://github.com/xinjianzhanghao/page-api-forwarder) | 它可以帮助您绕过某些API上的IP限制，并且由于它通过Cloudflare，因此速度很快。 |  |维护中|
 | [AI-worker](https://github.com/qyjoy/AI-worker) | 通过Cloudflare免费、私有化访问和管理Gemini~摆脱地域限制无烦恼，完全由自己掌控。 |  |维护中|
 | [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | 基于 Cloudflare Worker 和 Durable Objects 实现的 Gemini API 中转（多key负载均衡），稳定美国 IP 访问 Gemini | https://github.com/zaunist/gemini-balance-do | 维护中 |
+| [LLMKit](https://github.com/smigolsmigol/llmkit) | Open-source AI API gateway built on CF Workers + Durable Objects. Cost tracking, budget enforcement, rate limiting for 11 LLM providers (OpenAI, Anthropic, Gemini, etc). TypeScript SDK, CLI, MCP server. MIT license. | <https://github.com/smigolsmigol/llmkit> | 维护中 |
 
 
 ## 文件分享


### PR DESCRIPTION
Adds [LLMKit](https://github.com/smigolsmigol/llmkit) to the proxy section.

AI API gateway built on CF Workers + Durable Objects. Uses DOs for atomic budget enforcement with a reservation pattern (reserve estimated cost before request, settle after, release on failure). Session-scoped budgets, cost anomaly detection at 3x median, encrypted provider key vault. 11 providers, cache-aware pricing.

Also ships an MCP server (14 tools), Python SDK, TS SDK, CLI. MIT licensed, runs on free tier.