### PR TITLE
Add R2Drop - Native macOS menu bar uploader for Cloudflare R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 | [CloudPaste](https://github.com/ling-drag0n/CloudPaste) |基于Cloudflare的在线文本/大文件分享平台，支持多种语法 Markdown 渲染、阅后即焚、S3/WebDav/TG/OneDrive等多存储聚合、密码保护等功能，可作为WebDav挂载，支持Docker部署。| <https://doc.cloudpaste.qzz.io/>  |维护中|
 | [cf-drop](https://github.com/lyonbot/cf-drop) |一个「文件传输助手」，运行在 Cloudflare Worker + R2 + D1。具备PWA移动端优化、支持多线程文件下载、访问密码、打包下载tarball 等功能。界面简单易用，可放到浏览器侧栏，或者添加到手机桌面上快速使用。|   |维护中|
 | [serverless-webdav](https://github.com/jiacai2050/my-works/blob/main/serverless-webdav/README.zh-CN.md) | 基于 Cloudflare Workers 和 Cloudflare D1 数据库 构建的轻量级、可扩展的 WebDAV 服务器实现。 |   |维护中|
+| [R2Drop](https://github.com/superhumancorp/r2drop) |Native macOS menu bar app for uploading files to Cloudflare R2. Built with Swift + Rust, supports drag-and-drop, automatic URL copying, and multiple bucket management. | <https://r2drop.com> |维护中|
 
 
 


### PR DESCRIPTION
## R2Drop

[R2Drop](https://github.com/superhumancorp/r2drop) is a native macOS menu bar application for uploading files to Cloudflare R2 storage.

**Key features:**
- Built with Swift + Rust for native performance
- Drag-and-drop file uploads from the menu bar
- Automatic URL copying to clipboard
- Multiple bucket management
- Free tier support

**Website:** https://r2drop.com
**GitHub:** https://github.com/superhumancorp/r2drop

Added to the 文件分享 (File Sharing) section.