### PR TITLE
Add ducorn — Cloudflare full-stack publication (Pages + D1 + KV + R2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
 | [Rin](https://github.com/openRin/Rin/) |Rin 是一个基于 Cloudflare Pages + Workers + D1 + R2 全家桶的博客，无需服务器无需备案，只需要一个解析到 Cloudflare 的域名即可部署。| <https://docs.openrin.org/> | 维护中|
 | [cf-comment](https://github.com/joyance-professional/cf-comment) |一个基于 Cloudflare Workers 运行的简单评论系统，支持回复、点赞、举报以及管理员后台管理功能；同时提供中英双语切换，方便更广泛地使用。| <https://comment.joyance.page/area/test-4> | 维护中|
 | [Gins-Blog](https://github.com/IchimaruGin728/Gins-Blog) |一个高性能、Agentic-First 的博客平台。完全基于 Cloudflare 生态 (Workers, Pages, D1, KV, R2, Vectorize)。内置 MCP 协议，支持通过 OpenClaw 零人工自动部署。| <https://blog.ichimarugin728.com> | 维护中|
+| [讀角獸](https://ducorn.com) | 使用 Cloudflare Pages + Workers + D1 + KV + R2 全家桶構建的繁體中文深度分析出版物。Astro 4 hybrid SSR，零外部服務依賴。| <https://ducorn.com/> | 维护中|
 
 
 


### PR DESCRIPTION
讀角獸 (ducorn.com) 是一個用 Cloudflare 全家桶構建的繁體中文深度分析出版物：

- **Pages:** 靜態 + SSR 混合渲染（Astro 4 hybrid mode）
- **Workers:** API routes（auth, subscribe）
- **D1:** 內容、用戶、訂閱資料
- **KV:** Magic link session 存儲
- **R2:** 音頻和圖片存儲

技術棧：Astro 4.x + Tailwind CSS + Noto Sans TC

完全不依賴 AWS/Vercel/Supabase，是 Cloudflare 全家桶的實戰參考。

- 網站：https://ducorn.com