### PR TITLE
Add AIWatch to monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@
 | [deploy-mcp](https://github.com/alexpota/deploy-mcp) | 为AI助手提供的通用部署跟踪器，支持实时状态徽章和部署监控，包括对 Cloudflare Pages 的支持。 | https://deploy-mcp.io | 有效中 |
 | [What Broke Today](https://whatbroke.today/) | AI 驱动的宕机聚合器，追踪 100+ 云服务（包括 Cloudflare）的状态，提供实时 Telegram 警报、RSS 订阅和 JSON API。 | <https://whatbroke.today/> | 维护中 |
 | [oddin-status](https://github.com/oddinpay/oddin-status) | 精美的状态页与在线率监控系统。生产级环境就绪，开箱即用。| <https://status.oddinpay.com/> | 运行正常 |
+| [AIWatch](https://github.com/bentleypark/aiwatch) | 30 个 AI 服务（Claude、OpenAI、Gemini、Mistral、Groq、ElevenLabs 等）的实时状态监控仪表板。基于 Cloudflare Workers + KV + Workers AI（Gemma 4 26B 用于事件分析）构建，提供 Discord/Slack 告警、AI 驱动的事件分析和综合可靠性评分。 | <https://ai-watch.dev/> | 维护中 |
 
 ## 开发者工具
 


### PR DESCRIPTION
Adds AIWatch — a real-time status monitoring dashboard for 30 AI services (Claude, OpenAI, Gemini, Mistral, Groq, ElevenLabs, etc.), built on Cloudflare Workers + KV + Workers AI binding (Gemma 4 26B for incident analysis).

- Live demo: https://ai-watch.dev/
- Source: https://github.com/bentleypark/aiwatch (AGPL-3.0)
- Stack: Workers + KV (status cache, daily uptime counters, probe history) + Workers AI (Gemma 4) + AI Gateway (Sonnet fallback)

Fits the 监控 section alongside other Workers-based monitoring tools (UptimeFlare, cf-workers-status-page, oddin-status). Differentiator: AI-services-only focus + Detection Lead (catches incidents before official status pages).