### PR TITLE
Add ZeroLink to File Sharing section

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -120,6 +120,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [FileWorker](https://github.com/yllhwa/FileWorker) | Online-Clipboard/Dateifreigabe, die auf Cloudflare Worker läuft | | Wird gewartet |
 | [dingding](https://github.com/iiop123/dingding) | Ein Dateiübertragungstool, das auf Cloudflare Workers basiert, Dateien werden in Cloudflare KV gespeichert | | Scheint nicht gewartet zu werden |
 | [K-Vault](https://github.com/katelya77/K-Vault) | Serverlose aggregierte Cloud-Disk auf Basis von Telegram und Cloudflare. Unterstützt R2, S3, Discord, HuggingFace, Webhook-Direktupload, Inhaltsmoderation und benutzerdefinierte Domains. | | Wird gewartet |
+| [ZeroLink](https://github.com/yclgkd/ZeroLink) | Zero-Knowledge-Sicherheitsübertragungstool. Kein Konto erforderlich, Ende-zu-Ende-verschlüsselt, Server kann nicht entschlüsseln. Unterstützt Password / Passkey Dualmodus für die sichere Weitergabe von Passwörtern, API-Tokens, Wiederherstellungscodes, privaten Nachrichten und sensiblen Dateien. Basiert auf Cloudflare Workers + Durable Objects + R2. | <https://zerolink.dev> | Wird gewartet |
 
 ## Geschwindigkeitstest
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -150,6 +150,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [CloudPaste](https://github.com/ling-drag0n/CloudPaste) | A Cloudflare-based online text/large file sharing platform supporting multiple syntax Markdown rendering, self-destruct after reading, multi-storage aggregation (S3/WebDav/TG/OneDrive), password protection, and more. Can be mounted as WebDav and supports Docker deployment. | <https://doc.cloudpaste.qzz.io/> | Maintenance |
 | [dingding](https://github.com/iiop123/dingding) |A file transfer tool based on Cloudflare Workers, storing files in Cloudflare KV. |  | Seems unmaintained |
 | [K-Vault](https://github.com/katelya77/K-Vault) | Serverless cloud vault built around Telegram and Cloudflare. Supports R2, S3, Discord, HuggingFace, webhook uploads, content moderation, custom domains, and larger file extensions. |  | Maintaining |
+| [ZeroLink](https://github.com/yclgkd/ZeroLink) | Zero-knowledge secure sharing tool. No account needed, end-to-end encrypted, server cannot decrypt. Supports Password / Passkey dual modes for securely sharing passwords, API tokens, recovery codes, private messages, and sensitive files. Built on Cloudflare Workers + Durable Objects + R2. | <https://zerolink.dev> | Maintaining |
 
 ## Speed Test
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -149,6 +149,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [FileWorker](https://github.com/yllhwa/FileWorker) | Un portapapeles en línea/archivo compartido que funciona en Cloudflare Worker. |  | En mantenimiento |
 | [dingding](https://github.com/iiop123/dingding) | Una herramienta de transferencia de archivos basada en Cloudflare Workers, con archivos almacenados en Cloudflare KV. |  | Parece que no se mantiene |
 | [K-Vault](https://github.com/katelya77/K-Vault) | Bóveda en la nube serverless construida alrededor de Telegram y Cloudflare. Soporta R2, S3, Discord, HuggingFace, cargas por webhook, moderación de contenido y dominios personalizados. | | En mantenimiento |
+| [ZeroLink](https://github.com/yclgkd/ZeroLink) | Herramienta de transferencia segura de conocimiento cero. Sin cuenta necesaria, cifrado de extremo a extremo, el servidor no puede descifrar. Soporta modos duales Password / Passkey para compartir de forma segura contraseñas, tokens API, códigos de recuperación, mensajes privados y archivos sensibles. Construido sobre Cloudflare Workers + Durable Objects + R2. | <https://zerolink.dev> | En mantenimiento |
 
 ## Pruebas de velocidad
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@
 | [serverless-webdav](https://github.com/jiacai2050/my-works/blob/main/serverless-webdav/README.zh-CN.md) | 基于 Cloudflare Workers 和 Cloudflare D1 数据库 构建的轻量级、可扩展的 WebDAV 服务器实现。 |   |维护中|
 | [R2Drop](https://github.com/superhumancorp/r2drop) |Native macOS menu bar app for uploading files to Cloudflare R2. Built with Swift + Rust, supports drag-and-drop, automatic URL copying, and multiple bucket management. | <https://r2drop.com> |维护中|
 | [K-Vault](https://github.com/katelya77/K-Vault) | 基于 Cloudflare 的 Serverless 聚合云盘。以 Telegram 为核心，兼容 R2、S3、Discord、HuggingFace 等多存储后端，支持 Webhook 直传、2GB 扩展、内容审核和自定义域名。 |  |维护中|
+| [ZeroLink](https://github.com/yclgkd/ZeroLink) | 零知识安全传递工具，无账号、端到端加密、服务器无法解密；支持 Password / Passkey 双模式，适合安全传递密码、API Token、恢复码、私密消息和敏感文件。基于 Cloudflare Workers + Durable Objects + R2 构建。 | <https://zerolink.dev> |维护中|
 
 
 


### PR DESCRIPTION
## 建议添加：ZeroLink

**分类：** 文件分享 / File Sharing

| 名称 | 特性 | 在线地址 | 状态 |
| --- | --- | --- | --- |
| [ZeroLink](https://github.com/yclgkd/ZeroLink) | 零知识安全传递工具，无账号、端到端加密、服务器无法解密；支持 Password / Passkey 双模式，适合安全传递密码、API Token、恢复码、私密消息和敏感文件。基于 Cloudflare Workers + Durable Objects + R2 构建。 | https://zerolink.dev | 维护中 |

### 项目简介

ZeroLink 是一个基于 Cloudflare 构建的开源安全传递工具。发送方可以创建并管理分享，但服务端不保存明文，也无法解密内容，只有接收方可以解密查看。

### Cloudflare 技术栈

- **Cloudflare Workers** — 承载 API 和前端静态资源
- **Durable Objects（SQLite backend）** — 为每个 secret 提供原子状态机
- **R2** — 存储加密后的 multipart 文件分片
- Cloudflare 免费套餐即可部署

### 核心特性

- 无账号，打开即用
- 端到端加密，服务器零知识
- Quick Share（Password）/ Secure Share（Passkey）双模式
- 支持发送方管理，服务端始终不可解密
- 提供在线 Demo，也支持自部署

### 变更内容

在 4 个语言版本的 README 文件的"文件分享"章节末尾添加了 ZeroLink 条目：
- `README.md`（中文）
- `README-EN.md`（英文）
- `README-DE.md`（德语）
- `README-ES.md`（西班牙语）

Closes #142