### PR TITLE
Add HackMyIP to 开发者工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 | [Webhook Debugger](https://github.com/brancogao/webhook-debugger) | 自托管 Webhook 调试工具，支持签名验证（Stripe/GitHub/Slack/Shopify）、90天历史、全文搜索、一键重放。基于 Cloudflare Workers + D1 构建。 | <https://webhook-debugger.autocompany.workers.dev> | 维护中 |
 | [Cloudflare-WeChat-Notifier](https://github.com/krapnikkk/Cloudflare-WeChat-Notifier) | 基于 Cloudflare Workers + Hono + D1 + Queues 的微信通知桥接服务。支持扫码登录、Webhook 入站、异步投递、失败重试和日志追踪，适用于 CI/CD、监控告警等通知场景。 |  | 维护中 |
 | [GetWeb](https://github.com/ZhangShengFan/GetWeb) | 基于 Cloudflare Workers + GitHub Actions + Electron 的网页打包 EXE 工具。在线填写网址即可生成 Windows 桌面应用，支持自定义图标、构建历史和多 Token 负载均衡。 | <https://jishuguai.cc.cd/> | 维护中 |
+| [HackMyIP](https://hackmyip.com/) |基于 Cloudflare Workers 构建的在线隐私与网络工具集，提供 IP 查询、DNS/WebRTC 泄露检测、端口扫描、邮箱泄露检查、密码强度检测、网速测试等 20+ 工具，免费无需注册。 | <https://hackmyip.com/> | 维护中 |
 
 # 文章
 


### PR DESCRIPTION
Add [HackMyIP](https://hackmyip.com/) to the 开发者工具 (Developer Tools) section.

HackMyIP is a free privacy and network diagnostic toolkit built on Cloudflare Workers, offering 20+ tools including IP lookup, DNS/WebRTC leak detection, port scanning, email breach checking, password strength testing, speed test, and more. No registration required.

Built entirely on Cloudflare Workers + Pages.