### PR TITLE
Add Voidly Messenger — E2E messenger built on Cloudflare Pages + Workers + D1

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@
 | [TOPUPlive](https://www.topuplive.com/?utm_source=github&utm_medium=directory&utm_campaign=backlink) | 在线充值平台，支持手机充值、直播、游戏、礼品卡等 3000+ 商品类别。 | <https://www.topuplive.com/?utm_source=github&utm_medium=directory&utm_campaign=backlink> | 维护中 |
 | [Slitherlinks](https://slitherlinks.com) | 免费在线 Slitherlink 数字回路谜题平台，提供 1900+ 谜题、每日挑战、全球排行榜，技术栈包含 Cloudflare Workers + D1。 | <https://slitherlinks.com> | 维护中 |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1) | AI 驱动的学习工具，可将 PDF 学习资料转换为高质量 Anki 闪卡并导出卡组。 | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1> | 维护中 |
+| [Voidly Messenger](https://github.com/voidly-ai) | 完全基于 Cloudflare 构建的端到端加密消息 PWA（Pages + Workers + D1 + KV）。采用 Signal Protocol（Double Ratchet + X3DH）与 ML-KEM-768 后量子混合加密，全部加密在客户端完成，Workers 无法读取明文。 | <https://msg.voidly.ai> | 维护中 |
 
 ## 教程
 


### PR DESCRIPTION
## What

Adds **Voidly Messenger** (<https://msg.voidly.ai>) to the list — a fully end-to-end encrypted messenger PWA built entirely on Cloudflare's platform.

## Cloudflare-native stack

- **Pages** — frontend at `msg.voidly.ai` (PWA, installable)
- **Workers** — relay at `api.voidly.ai/v1/agent/*` (never sees plaintext)
- **D1** — encrypted message + identity storage on the relay
- **KV** — rate limits, session state

No external servers. The entire messaging substrate — including the relay — runs on Cloudflare.

## Crypto stack

- **Signal Protocol** — Double Ratchet (DH ratchet + hash ratchet, per-message forward secrecy + post-compromise recovery) + X3DH async key agreement with signed prekeys + one-time prekeys
- **ML-KEM-768** — NIST FIPS 203 post-quantum hybrid key exchange (harvest-now-decrypt-later resistant)
- **Client-side only** — all encryption happens in the browser via `@voidly/agent-sdk` (tweetnacl + ml-kem). Private keys never leave the client. The Worker sees only ciphertext.
- **Deniable auth**, sealed sender, padding, replay protection, TOFU key pinning

Useful as a public example of building serious cryptography software on Cloudflare's platform — the whole relay is a Worker, with D1 for durable storage and KV for rate limits.

## Why this fits

The list already includes several privacy/encryption tools (e.g. [ZeroLink](https://zerolink.dev) in 文件分享). Voidly Messenger extends that category into real-time E2E messaging, and is one of the few serious Signal-Protocol-on-Cloudflare implementations.

Source across `github.com/voidly-ai`. Maintainer: @EmperorMew.

Happy to adjust the category placement or description format if preferred.