### PR TITLE
Add Dualmark — AEO infrastructure for Cloudflare Workers

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -213,6 +213,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | [Slitherlinks](https://slitherlinks.com) | Kostenlose Online-Slitherlink-Plattform mit über 1900 Rätseln, täglichen Herausforderungen, globalen Ranglisten und Cloudflare Workers + D1 Stack. | <https://slitherlinks.com> | Wird gewartet |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1) | KI-gestützte Lernplattform, die PDFs in hochwertige Anki-Karteikarten mit exportierbaren Decks umwandelt. | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1> | Wird gewartet |
 | [OmniConvert](https://github.com/s87343472/omni-convert) | Kostenloser Online-Konvertierungsbaukasten auf Cloudflare Pages + Workers. Unterstützt Dateikonvertierung, Einheitenumrechnung, PWA, mehrsprachige Oberfläche und API/MCP-Zugriff. | <https://tools.sagasu.art> | Wird gewartet |
+| [Dualmark](https://github.com/dodopayments/dualmark) | Open-Source-AEO-Infrastruktur (Answer Engine Optimization). Der `@dualmark/cloudflare`-Adapter umschließt jeden Upstream-Worker und liefert KI-Crawlern (GPTBot, ClaudeBot, PerplexityBot, +16 bekannte UAs) am Edge via HTTP-Content-Negotiation sauberes Markdown, Menschen erhalten HTML — gleiche URL, zwei Formate. Apache 2.0, mit npm provenance signiert. | <https://dualmark.dev> | Wird gewartet |
 
 
 ## Tutorials

--- a/README-EN.md
+++ b/README-EN.md
@@ -244,6 +244,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [Slitherlinks](https://slitherlinks.com) | Free online Slitherlink puzzle platform with 1900+ puzzles, daily challenges, global leaderboards, and a Cloudflare Workers + D1 stack. | <https://slitherlinks.com> | Maintaining |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1) | AI-powered study platform that converts PDFs into high-quality Anki flashcards with export-ready decks. | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1> | Maintaining |
 | [OmniConvert](https://github.com/s87343472/omni-convert) | Free online conversion toolbox deployed on Cloudflare Pages + Workers. Supports file conversion, unit conversion, PWA, multilingual UI, and API/MCP access. | <https://tools.sagasu.art> | Maintaining |
+| [Dualmark](https://github.com/dodopayments/dualmark) | Open-source AEO (Answer Engine Optimization) infrastructure. The `@dualmark/cloudflare` adapter wraps any upstream Worker and serves clean Markdown twins to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 more known UAs) at the edge via HTTP content negotiation, while humans get HTML — same URL, two formats. Apache 2.0, npm provenance attested. | <https://dualmark.dev> | Maintaining |
 
 
 ## Tutorials

--- a/README-ES.md
+++ b/README-ES.md
@@ -243,6 +243,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | [Slitherlinks](https://slitherlinks.com) | Plataforma gratuita de Slitherlink en línea con más de 1900 rompecabezas, desafíos diarios, clasificaciones globales y una pila basada en Cloudflare Workers + D1. | <https://slitherlinks.com> | En mantenimiento |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1) | Plataforma de estudio con IA que convierte PDFs en tarjetas Anki de alta calidad con mazos listos para exportar. | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1> | En mantenimiento |
 | [OmniConvert](https://github.com/s87343472/omni-convert) | Caja de herramientas gratuita de conversión en línea desplegada en Cloudflare Pages + Workers. Soporta conversión de archivos, unidades, PWA, interfaz multilingüe y acceso API/MCP. | <https://tools.sagasu.art> | En mantenimiento |
+| [Dualmark](https://github.com/dodopayments/dualmark) | Infraestructura AEO (Answer Engine Optimization) de código abierto. El adaptador `@dualmark/cloudflare` envuelve cualquier Worker y sirve copias en Markdown a rastreadores de IA (GPTBot, ClaudeBot, PerplexityBot, +16 UAs conocidas) mediante negociación de contenido HTTP en el edge, mientras los humanos reciben HTML — misma URL, dos formatos. Apache 2.0, atestado con npm provenance. | <https://dualmark.dev> | En mantenimiento |
 
 
 ## Tutoriales

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@
 | [Cloudflare-WeChat-Notifier](https://github.com/krapnikkk/Cloudflare-WeChat-Notifier) | 基于 Cloudflare Workers + Hono + D1 + Queues 的微信通知桥接服务。支持扫码登录、Webhook 入站、异步投递、失败重试和日志追踪，适用于 CI/CD、监控告警等通知场景。 |  | 维护中 |
 | [GetWeb](https://github.com/ZhangShengFan/GetWeb) | 基于 Cloudflare Workers + GitHub Actions + Electron 的网页打包 EXE 工具。在线填写网址即可生成 Windows 桌面应用，支持自定义图标、构建历史和多 Token 负载均衡。 | <https://jishuguai.cc.cd/> | 维护中 |
 | [HackMyIP](https://hackmyip.com/) |基于 Cloudflare Workers 构建的在线隐私与网络工具集，提供 IP 查询、DNS/WebRTC 泄露检测、端口扫描、邮箱泄露检查、密码强度检测、网速测试等 20+ 工具，免费无需注册。 | <https://hackmyip.com/> | 维护中 |
+| [Dualmark](https://github.com/dodopayments/dualmark) | 开源 AEO（Answer Engine Optimization）基础设施。`@dualmark/cloudflare` 适配器包装任意上游 Worker，在边缘通过 HTTP 内容协商为 AI 爬虫（GPTBot、ClaudeBot、PerplexityBot 等 19 个已知 UA）返回干净的 Markdown 副本，人类访客获得 HTML，同一 URL 双格式。Apache 2.0，npm provenance 签名。 | <https://dualmark.dev> | 维护中 |
 
 # 文章
 


### PR DESCRIPTION
Adds [Dualmark](https://github.com/dodopayments/dualmark) under the **Developer Tools** / **Others** section of all four language READMEs (zh / EN / ES / DE) for parity.

**What it is:** Open-source AEO (Answer Engine Optimization) infrastructure. The [`@dualmark/cloudflare`](https://www.npmjs.com/package/@dualmark/cloudflare) adapter wraps any upstream Worker (Hono, itty-router, Cloudflare Pages Functions, plain `fetch` handler) and serves clean Markdown twins to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 known UAs) at the edge via HTTP content negotiation. Humans get HTML — same URL, two formats, picked at <10ms.

- Live: https://dualmark.dev (the docs site dogfoods the spec)
- Repo: https://github.com/dodopayments/dualmark
- 6 npm packages (`@dualmark/{core,converters,astro,nextjs,cloudflare,cli}`)
- 313 tests, 125/125 self-conformance
- Apache 2.0, npm provenance attested (Sigstore-signed, verifiable with `npm audit signatures`)
- Public AEO Spec v1.0 (RFC-2119) at https://github.com/dodopayments/dualmark/tree/main/spec

Translations were done carefully — happy to fix any phrasing issues if a native speaker spots something off in the ES/DE versions.