### PR TITLE
Add AnyRouter - universal AI model router on Cloudflare Workers

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -140,6 +140,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [CF-Workers-docker.io](https://github.com/cmliu/CF-Workers-docker.io) | This project is a Docker image proxy tool based on Cloudflare Workers. It can relay requests to the official Docker image repository, solving access restrictions and accelerating access. | <https://docker.fxxk.dedyn.io/> | Maintaining |
 | [cf-workers-proxy](https://github.com/jonssonyan/cf-workers-proxy) | Cloudflare Workers HTTP reverse proxy, theoretically supports proxying any blocked domain name, just set the environment variable PROXY_HOSTNAME to the blocked domain name |  | Maintaining |
 | [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | Based on Cloudflare Worker and Durable Objects, this project implements a Gemini API relay (multi-key load balancing) for stable US IP access to Gemini. | https://github.com/zaunist/gemini-balance-do | Maintained |
+| [AnyRouter](https://anyrouter.dev) | Universal AI model router built on Cloudflare Workers + D1 + KV. Routes to 150+ models across 28+ providers with unified billing, BYOK, and automatic provider fallbacks. | <https://anyrouter.dev> | Maintaining |
 
 ## File Sharing
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 | [AI-worker](https://github.com/qyjoy/AI-worker) | 通过Cloudflare免费、私有化访问和管理Gemini~摆脱地域限制无烦恼，完全由自己掌控。 |  |维护中|
 | [gemini-balance-do](https://github.com/zaunist/gemini-balance-do) | 基于 Cloudflare Worker 和 Durable Objects 实现的 Gemini API 中转（多key负载均衡），稳定美国 IP 访问 Gemini | https://github.com/zaunist/gemini-balance-do | 维护中 |
 | [LLMKit](https://github.com/smigolsmigol/llmkit) | Open-source AI API gateway built on CF Workers + Durable Objects. Cost tracking, budget enforcement, rate limiting for 11 LLM providers (OpenAI, Anthropic, Gemini, etc). TypeScript SDK, CLI, MCP server. MIT license. | <https://github.com/smigolsmigol/llmkit> | 维护中 |
+| [AnyRouter](https://anyrouter.dev) | 基于 Cloudflare Workers + D1 + KV 构建的通用 AI 模型路由器。一个 OpenAI 兼容的 API 网关，路由到 150+ 模型（28+ 供应商），支持统一计费、BYOK 和自动供应商回退。 | <https://anyrouter.dev> | 维护中 |
 
 
 ## 文件分享


### PR DESCRIPTION
## Summary

Added [AnyRouter](https://anyrouter.dev) to the Acceleration section in both Chinese and English READMEs.

AnyRouter is a universal AI model router built on Cloudflare Workers + D1 + KV:
- Routes to 150+ AI models across 28+ providers
- OpenAI-compatible API gateway
- Unified billing, audit logs, and real-time pricing
- BYOK (Bring Your Own Key) support
- Automatic provider fallbacks
- MCP server for AI agents

Similar to the existing LLMKit entry, but focuses on managed multi-provider routing rather than self-hosted gateway.

## Checklist

- [x] Added to both Chinese (README.md) and English (README-EN.md)
- [x] Follows existing table format (Name | Features | Online Address | Status)
- [x] Added to the Acceleration section alongside similar API relay tools