### PR TITLE
Add Agora Cosmica to Others section

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -244,6 +244,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [Slitherlinks](https://slitherlinks.com) | Free online Slitherlink puzzle platform with 1900+ puzzles, daily challenges, global leaderboards, and a Cloudflare Workers + D1 stack. | <https://slitherlinks.com> | Maintaining |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1) | AI-powered study platform that converts PDFs into high-quality Anki flashcards with export-ready decks. | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1> | Maintaining |
 | [OmniConvert](https://github.com/s87343472/omni-convert) | Free online conversion toolbox deployed on Cloudflare Pages + Workers. Supports file conversion, unit conversion, PWA, multilingual UI, and API/MCP access. | <https://tools.sagasu.art> | Maintaining |
+| [Agora Cosmica](https://github.com/chipmates/agoracosmica) | Self-hostable educational platform built on Cloudflare Pages + 4 Workers (LLM proxy, audio proxy, community, stats) + R2. 30 historical figures from philosophy, science, art, mysticism, and activism for stories, dialogues, and multi-figure councils. AGPL-3.0, BYOK LLM, no user tracking. | <https://agoracosmica.org> | Maintaining |
 
 
 ## Tutorials

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@
 | [Slitherlinks](https://slitherlinks.com) | 免费在线 Slitherlink 数字回路谜题平台，提供 1900+ 谜题、每日挑战、全球排行榜，技术栈包含 Cloudflare Workers + D1。 | <https://slitherlinks.com> | 维护中 |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1) | AI 驱动的学习工具，可将 PDF 学习资料转换为高质量 Anki 闪卡并导出卡组。 | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1> | 维护中 |
 | [Voidly Messenger](https://github.com/voidly-ai) | 完全基于 Cloudflare 构建的端到端加密消息 PWA（Pages + Workers + D1 + KV）。采用 Signal Protocol（Double Ratchet + X3DH）与 ML-KEM-768 后量子混合加密，全部加密在客户端完成，Workers 无法读取明文。 | <https://msg.voidly.ai> | 维护中 |
+| [Agora Cosmica](https://github.com/chipmates/agoracosmica) | Self-hostable educational platform built on Cloudflare Pages + 4 Workers (LLM proxy, audio proxy, community, stats) + R2. 30 historical figures from philosophy, science, art, mysticism, and activism for stories, dialogues, and multi-figure councils. AGPL-3.0, BYOK LLM, no user tracking. | <https://agoracosmica.org> | 维护中 |
 
 ## 教程
 


### PR DESCRIPTION
Hi! Adding Agora Cosmica to the Others section.

Agora Cosmica is a self-hostable educational platform with 30 historical figures from philosophy, science, art, mysticism, and activism. Users can listen to narrated stories, engage in structured dialogues, have live AI conversations, or convene multi-figure councils across history.

**Cloudflare stack:**
- Cloudflare Pages for the React + Astro app
- 4 Workers: LLM proxy (BYOK + free tier rate limiting), audio proxy, community feedback, stats
- R2 for content (images, audio, JSON) with 1-year immutable edge cache

Open-source under AGPL-3.0, by ChipMates gemeinnützige GmbH (German nonprofit, charitable purpose: advancement of education).

- Repo: https://github.com/chipmates/agoracosmica
- Live: https://agoracosmica.org

Thanks for maintaining this list!