### PR TITLE
add cfzt to Tunnel section

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -127,6 +127,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | Name | Features | Online Address | Status |
 | --- | --- | --- |--- |
 | [Cloudflared-web](https://github.com/WisdomSky/Cloudflared-web) |Cloudflared-web is a Docker image that bundles the Cloudflared CLI and a simple web UI for easily starting/stopping Cloudflare tunnels. |  | Maintaining |
+| [cfzt](https://github.com/casablanque-code/cfzt) | CLI tool that wraps Cloudflare Tunnel, DNS, and Access into single commands for streamlined Zero Trust deployments. Written in Go. | | Maintaining |
 
 ## Acceleration
 


### PR DESCRIPTION
cfzt is a Go CLI that wraps Cloudflare Tunnel, DNS, and Access into single commands.