### PR TITLE
Add Prismix to Monitoring section — AI status hub on Cloudflare Workers + KV

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -169,6 +169,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [xugou](https://github.com/zaunist/xugou)| A website monitoring and server monitoring tool based on CloudFlare. | https://xugou.mdzz.uk/ |  Under maintenance |
 | [deploy-mcp](https://github.com/alexpota/deploy-mcp) | Universal deployment tracker for AI assistants with live status badges and deployment monitoring, including Cloudflare Pages support. | https://deploy-mcp.io | Active |
 | [oddin-status](https://github.com/oddinpay/oddin-status) | Beautiful status page & uptime monitor. Ready for production out of the box. | <https://status.oddinpay.com/> | Active |
+| [Prismix](https://prismix.dev) | Real-time status aggregator for 76 AI services (OpenAI, Anthropic, Cursor, and more), built entirely on Cloudflare Workers + KV. Features email/webhook alerts, 30-day uptime history, status badges, AI news aggregation, and MCP server directory. | <https://prismix.dev> | Active |
 
 
 ## Articles

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 | [What Broke Today](https://whatbroke.today/) | AI 驱动的宕机聚合器，追踪 100+ 云服务（包括 Cloudflare）的状态，提供实时 Telegram 警报、RSS 订阅和 JSON API。 | <https://whatbroke.today/> | 维护中 |
 | [oddin-status](https://github.com/oddinpay/oddin-status) | 精美的状态页与在线率监控系统。生产级环境就绪，开箱即用。| <https://status.oddinpay.com/> | 运行正常 |
 | [AIWatch](https://github.com/bentleypark/aiwatch) | 30 个 AI 服务（Claude、OpenAI、Gemini、Mistral、Groq、ElevenLabs 等）的实时状态监控仪表板。基于 Cloudflare Workers + KV + Workers AI（Gemma 4 26B 用于事件分析）构建，提供 Discord/Slack 告警、AI 驱动的事件分析和综合可靠性评分。 | <https://ai-watch.dev/> | 维护中 |
+| [Prismix](https://prismix.dev) | AI monitoring for 76 services (OpenAI, Anthropic, Cursor...) on Cloudflare Workers+KV. Email/webhook alerts, 30-day uptime, status badges, news aggregation, MCP directory. | <https://prismix.dev> | Active |
 
 ## 开发者工具
 


### PR DESCRIPTION
## What

Adds [Prismix](https://prismix.dev) to the **监控 / Monitoring** section in both `README.md` and `README-EN.md`.

## About Prismix

Prismix is a real-time AI service status aggregator and hub, built entirely on **Cloudflare Workers + KV + Pages**:

- **76 AI services monitored** — OpenAI, Anthropic, Cursor, GitHub Copilot, Groq, Gemini, DeepSeek, and more
- **Email + webhook alerts** on status changes (Cloudflare KV-backed)
- **30-day uptime history** + incident timeline per service
- **Embeddable status badges** (`/api/badge/{id}.svg`)
- **AI news aggregation** from 70+ curated sources
- **MCP server directory** with 500+ servers and bundles
- **$0/mo to run** on Cloudflare free tier (Workers + KV + Pages)

Similar in spirit to AIWatch (already in the list), but monitoring 76 services specifically with a 3-pillar architecture (status + news + MCP).

Live: https://prismix.dev

Updated both Chinese and English READMEs.