### PR TITLE
Add create-microservices-app to 脚手架

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 | 名称 | 特性 |在线地址 | 状态|
 | --- | --- | --- |---|
 | [nextflare](https://github.com/ccbikai/nextflare) |Next.js App running with Lemon Squeezy on Cloudflare. |   <https://nextflare-template.pages.dev/> | 维护中|
+| [create-microservices-app](https://github.com/microservices-sh/microservices-sh/tree/main/packages/create-microservices-app) | Scaffold a Cloudflare-native SaaS app — Workers, D1, SvelteKit/Hono, with verified auth, booking, payment & email modules. | <https://microservices.sh> | 维护中|
 
 ## 短链
 


### PR DESCRIPTION
Adds [create-microservices-app](https://github.com/microservices-sh/microservices-sh/tree/main/packages/create-microservices-app) to the 脚手架 (Scaffold) section.

It is an open-source `npm create` CLI that scaffolds a Cloudflare-native app — Workers, D1, and Wrangler config — from verified modules (auth, booking, payment, email), with SvelteKit and Hono templates. Published on npm; site at https://microservices.sh. Fits alongside the existing nextflare entry.