### PR TITLE
[Add] released — find which release contains a commit/PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@
 | [Cloudflare-WeChat-Notifier](https://github.com/krapnikkk/Cloudflare-WeChat-Notifier) | 基于 Cloudflare Workers + Hono + D1 + Queues 的微信通知桥接服务。支持扫码登录、Webhook 入站、异步投递、失败重试和日志追踪，适用于 CI/CD、监控告警等通知场景。 |  | 维护中 |
 | [GetWeb](https://github.com/ZhangShengFan/GetWeb) | 基于 Cloudflare Workers + GitHub Actions + Electron 的网页打包 EXE 工具。在线填写网址即可生成 Windows 桌面应用，支持自定义图标、构建历史和多 Token 负载均衡。 | <https://jishuguai.cc.cd/> | 维护中 |
 | [HackMyIP](https://hackmyip.com/) |基于 Cloudflare Workers 构建的在线隐私与网络工具集，提供 IP 查询、DNS/WebRTC 泄露检测、端口扫描、邮箱泄露检查、密码强度检测、网速测试等 20+ 工具，免费无需注册。 | <https://hackmyip.com/> | 维护中 |
+| [released](https://github.com/lukaso/released) | Find the first release tag that contains a commit or merged PR. Built on Cloudflare Workers, Containers, and Service Bindings. | <https://released.blabberate.com> | 维护中 |
 
 # 文章
 


### PR DESCRIPTION
Adds released to the Developer Tools section.

released finds the first release tag that contains a commit or merged PR/MR, for any public GitHub repo and several GitLab hosts. It runs on Cloudflare Workers, with a Containers relay and Service Bindings. Live: https://released.blabberate.com — source (MIT): https://github.com/lukaso/released