### PR TITLE
[codex] add CloudSSH to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@
 | [Cloudflare-WeChat-Notifier](https://github.com/krapnikkk/Cloudflare-WeChat-Notifier) | 基于 Cloudflare Workers + Hono + D1 + Queues 的微信通知桥接服务。支持扫码登录、Webhook 入站、异步投递、失败重试和日志追踪，适用于 CI/CD、监控告警等通知场景。 |  | 维护中 |
 | [GetWeb](https://github.com/ZhangShengFan/GetWeb) | 基于 Cloudflare Workers + GitHub Actions + Electron 的网页打包 EXE 工具。在线填写网址即可生成 Windows 桌面应用，支持自定义图标、构建历史和多 Token 负载均衡。 | <https://jishuguai.cc.cd/> | 维护中 |
 | [HackMyIP](https://hackmyip.com/) |基于 Cloudflare Workers 构建的在线隐私与网络工具集，提供 IP 查询、DNS/WebRTC 泄露检测、端口扫描、邮箱泄露检查、密码强度检测、网速测试等 20+ 工具，免费无需注册。 | <https://hackmyip.com/> | 维护中 |
+| [CloudSSH](https://github.com/newbietan/CloudSSH) | 基于 Cloudflare Workers + Durable Objects + TCP Sockets 的 Serverless Web SSH 终端，支持密码和 Ed25519 私钥认证。 | <https://ssh.newbietan.cn/> | 维护中 |
 
 # 文章
 


### PR DESCRIPTION
## Summary
- add CloudSSH to the developer tools section
- include its GitHub repository, demo URL, and a short Cloudflare Workers based description

## Validation
- `git diff --check`
- confirmed `newbietan/CloudSSH` is public, not archived, Apache-2.0 licensed, and based on TypeScript / Cloudflare Workers

Closes #166