### PR TITLE
Add Lunora to Scaffolding / 脚手架新增 Lunora

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -92,6 +92,7 @@ Willkommen zu PRs und Issues für Updates. Bei Problemen während der Bereitstel
 | Name | Merkmale | Online-Adresse | Status |
 | --- | --- | --- | --- |
 | [nextflare](https://github.com/ccbikai/nextflare) | Next.js App, die mit Lemon Squeezy auf Cloudflare läuft. | <https://nextflare-template.pages.dev/> | Wartung |
+| [Lunora](https://github.com/anolilab/lunora) | Typsicheres Echtzeit-Backend-Framework für Cloudflare Workers + Durable Objects. Definiere ein Schema und schreibe query/mutation/action-Funktionen; Clients erhalten Ende-zu-Ende typisierte Daten mit Live-Subscriptions, optimistischen Updates und einer Offline-Queue. Convex-artige DX, Vite-first, in deinem eigenen Cloudflare-Konto. | <https://lunora.sh> | Wartung |
 
 ## Tunnel
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -96,6 +96,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | Name | Features | Online Address | Status |
 | --- | --- | --- | --- |
 | [nextflare](https://github.com/ccbikai/nextflare) | Next.js App running with Lemon Squeezy on Cloudflare. | <https://nextflare-template.pages.dev/> | Maintenance |
+| [Lunora](https://github.com/anolilab/lunora) | Type-safe, real-time backend framework for Cloudflare Workers + Durable Objects. Define a schema and write query/mutation/action functions; clients get end-to-end typed data with live subscriptions, optimistic updates and an offline queue. Convex-style DX, Vite-first, on your own Cloudflare account. | <https://lunora.sh> | Maintenance |
 
 ## Short Links
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -96,6 +96,7 @@ Se invita a contribuir con PR y issues para actualizaciones. Si tienes algún pr
 | Nombre | Características | Dirección en línea | Estado |
 | --- | --- | --- | --- |
 | [nextflare](https://github.com/ccbikai/nextflare) | Aplicación Next.js que se ejecuta con Lemon Squeezy en Cloudflare. | <https://nextflare-template.pages.dev/> | Mantenimiento |
+| [Lunora](https://github.com/anolilab/lunora) | Framework de backend en tiempo real y con tipado seguro para Cloudflare Workers + Durable Objects. Define un esquema y escribe funciones query/mutation/action; los clientes obtienen datos tipados de extremo a extremo con suscripciones en vivo, actualizaciones optimistas y una cola sin conexión. Experiencia de desarrollo estilo Convex, con Vite, en tu propia cuenta de Cloudflare. | <https://lunora.sh> | Mantenimiento |
 
 ## Enlaces cortos
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------ |
 | [nextflare](https://github.com/ccbikai/nextflare)                                                                            | Next.js App running with Lemon Squeezy on Cloudflare.                                                                      | <https://nextflare-template.pages.dev/> | 维护中 |
 | [create-microservices-app](https://github.com/microservices-sh/microservices-sh/tree/main/packages/create-microservices-app) | Scaffold a Cloudflare-native SaaS app — Workers, D1, SvelteKit/Hono, with verified auth, booking, payment & email modules. | <https://microservices.sh>              | 维护中 |
+| [Lunora](https://github.com/anolilab/lunora)                                                                                 | 基于 Cloudflare Workers + Durable Objects 的类型安全实时后端框架。定义 schema 并编写 query/mutation/action 函数，客户端即可获得端到端类型安全数据，支持实时订阅、乐观更新与离线队列。Convex 风格开发体验，Vite 优先，部署在你自己的 Cloudflare 账号上。 | <https://lunora.sh>                     | 维护中 |
 
 ## 短链
 


### PR DESCRIPTION
### What / 简介

Adds **[Lunora](https://github.com/anolilab/lunora)** to the **Scaffolding / 脚手架** section.

Lunora 是一个基于 **Cloudflare Workers + Durable Objects** 的类型安全实时后端框架：定义 schema 并编写 query/mutation/action 函数，客户端即可获得端到端类型安全的数据，支持实时订阅、乐观更新与离线队列。Convex 风格开发体验，Vite 优先，全部部署在你自己的 Cloudflare 账号上（D1、R2、Queues、鉴权、支付、AI 等）。

Lunora is a type-safe, real-time backend framework for Cloudflare Workers + Durable Objects — Convex-style DX, Vite-first, running entirely on your own Cloudflare account.

### Why it fits / 收录理由

- ✅ 开源 (open source) — https://github.com/anolilab/lunora
- ✅ 基于 Cloudflare (Workers, Durable Objects, D1, R2, Queues)
- ✅ 帮助独立开发者提升开发效率、降低成本、快速上手
- 🌐 官网 / Website: https://lunora.sh

### Changes

Added one row to the Scaffolding table in all four language READMEs:

- `README.md` (中文)
- `README-EN.md`
- `README-ES.md`
- `README-DE.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)