### PR TITLE
Add Agent Post Office to email projects

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -78,6 +78,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [zmail](https://github.com/zaunist/zmail) | Z-Mail - A minimalist temporary email service built on CloudFlare's pages, worker, and D1 SQL, supporting attachment reception. | <https://mail.mdzz.uk/> | Maintaining |
 | [Alle](https://github.com/bestruirui/Alle) | AI-powered email aggregation client with verification code extraction and link classification. Features temporary email service. Built on Cloudflare Workers + Next.js, serverless deployment with just a domain. | | Maintaining |
 | [FreeTempMail](https://github.com/PennyJoly/FreeTempMail) | A clean and minimalist permanent free temporary email service. Protects user privacy, supports i18n internationalization, use and go. Built with NuxtPro template and Cloudflare. | <https://mail.aitre.cc> | Maintaining |
+| [Agent Post Office](https://github.com/Agent-Post-Office/agentpostoffice-cloudflare) | Self-hosted custom-domain email infrastructure for AI agents on Cloudflare Workers, with REST, CLI, MCP, threading, and attachment support. Developer preview. | <https://agentpostoffice.com/> | Maintaining |
 
 ## Blog
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 | [cloud-mail](https://github.com/LaziestRen/cloud-mail)                            | 用Vue3开发的响应式简约邮箱服务，支持邮件发送附件收发，可以部署到Cloudflare云平台。                                                                                                                                                                                                 | <https://skymail.ink>   | 维护中 |
 | [Alle](https://github.com/bestruirui/Alle)                                        | AI识别的邮件聚合客户端，支持验证码提取、链接分类、临时邮箱服务。基于Cloudflare Workers + Next.js构建，无需服务器，仅需一个域名即可部署。                                                                                                                                           |                         | 维护中 |
 | [FreeTempMail](https://github.com/PennyJoly/FreeTempMail)                         | 清爽简约风的永久免费临时邮件服务。保护用户隐私数据，支持i18n国际化，即用即走。基于NuxtPro模板和CF开发。                                                                                                                                                                            | <https://mail.aitre.cc> | 维护中 |
+| [Agent Post Office](https://github.com/Agent-Post-Office/agentpostoffice-cloudflare) | 面向 AI 智能体的自托管自定义域名邮件基础设施，基于 Cloudflare Workers，提供 REST、CLI、MCP、会话和附件支持（开发者预览版）。                                                                                                                                            | <https://agentpostoffice.com/> | 维护中 |
 
 
 ## 博客


### PR DESCRIPTION
## Summary

- Add Agent Post Office to the English **Email** table.
- Mirror the entry in the Chinese **邮箱** table.
- Describe its self-hosted Cloudflare architecture and developer-preview status.

Agent Post Office is an Apache-2.0 email infrastructure project for AI agents. It provides custom-domain mailboxes through REST, CLI, and MCP interfaces, with threading and attachment support.

## Verification

- `git diff --check`
- Confirmed the GitHub repository and project website both return HTTP 200.
