### PR TITLE
Add FlareStarter to 脚手架

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------ |
 | [nextflare](https://github.com/ccbikai/nextflare)                                                                            | Next.js App running with Lemon Squeezy on Cloudflare.                                                                      | <https://nextflare-template.pages.dev/> | 维护中 |
 | [create-microservices-app](https://github.com/microservices-sh/microservices-sh/tree/main/packages/create-microservices-app) | Scaffold a Cloudflare-native SaaS app — Workers, D1, SvelteKit/Hono, with verified auth, booking, payment & email modules. | <https://microservices.sh>              | 维护中 |
+| [FlareStarter](https://github.com/FlareStarter/flarestarter)                                                                 | TanStack Start + Cloudflare Workers 的全栈 SaaS 起步模板。Workers + D1 + KV + R2，内置认证(better-auth)、计费(Stripe)、邮件(Resend)、i18n、SEO、运营后台，无 mock、有测试、优雅降级，fork 即用。 | <https://flarestarter.com>              | 维护中 |
 
 ## 短链
 


### PR DESCRIPTION
Closes #190.

## 新增条目：FlareStarter（脚手架）

在「脚手架」分类新增一行 FlareStarter —— 基于 **TanStack Start + Cloudflare Workers** 的全栈、边缘原生 SaaS 起步模板。

- **仓库**：https://github.com/FlareStarter/flarestarter
- **在线 Demo**：https://flarestarter.com
- **文档**：https://flarestarter.com/docs

### 简介
运行在 Workers + D1 + KV + R2 上，0 成本起步。内置认证(better-auth，含 Google/GitHub OAuth)、计费(Stripe 订阅 + 终身买断)、邮件(Resend)、R2 头像上传、等待列表、更新日志、反馈箱、赞助页、i18n(中/英)、SEO、运营后台。**无 mock、无占位，每个功能都是真实实现且有测试**(Vitest：Node 单测 + `@cloudflare/vitest-pool-workers` 的 D1 集成测试)；可选集成(Stripe/Resend/Turnstile/Sentry)缺 key 时优雅降级。端到端 TypeScript 类型安全，fork 即用。

与同分类的 create-microservices-app 属同类项目（Cloudflare 原生 SaaS 脚手架）。
