### PR TITLE
docs(隧道): 新增 Cloudflare-Edgetunnel 条目

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 | 名称                                                            | 特性                                                                                                              | 在线地址 | 状态   |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | ------ |
 | [Cloudflared-web](https://github.com/WisdomSky/Cloudflared-web) | Cloudflared-web 是一个 docker 镜像，它打包了 cloudflared cli 和简单的 Web UI，以便轻松启动/停止 cloudflare 隧道。 |          | 维护中 |
+| [Cloudflare-Edgetunnel](https://github.com/Royo-Qiao/Cloudflare-Edgetunnel) | 本地 Web 向导，一键把 cmliu/edgetunnel（VLESS+WS+TLS）节点部署到 Cloudflare Pages：自动创建 KV/Pages 项目、绑定自定义域名，TCP 测速优选 CF IP 写入订阅，Clash 导入即用；含自托管管理后台，MIT 许可。 |          | 维护中 |
 
 ## 加速
 


### PR DESCRIPTION
## 收录项目

[Cloudflare-Edgetunnel](https://github.com/Royo-Qiao/Cloudflare-Edgetunnel)（本人维护的项目，如实披露）

## 与「隧道」分区的契合点

- 基于 Cloudflare Tunnel 生态（上游 [cmliu/edgetunnel](https://github.com/cmliu/edgetunnel)，VLESS+WS+TLS）的一键部署工具；
- 本地 Web 向导：自动创建 Workers KV / Pages 项目、绑定自定义域名，TCP 测速优选 CF IP 写入订阅，Clash 导入即用；
- MIT 许可，活跃维护中，README 含完整动态演示（WebP）。

## 变更

仅在「隧道」表格追加一行，未改动其他内容。
