### PR TITLE
Add cfex-cli to Tunnel section

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -129,6 +129,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | --- | --- | --- |--- |
 | [Cloudflared-web](https://github.com/WisdomSky/Cloudflared-web) |Cloudflared-web is a Docker image that bundles the Cloudflared CLI and a simple web UI for easily starting/stopping Cloudflare tunnels. |  | Maintaining |
 | [cfzt](https://github.com/casablanque-code/cfzt) | CLI tool that wraps Cloudflare Tunnel, DNS, and Access into single commands for streamlined Zero Trust deployments. Written in Go. | | Maintaining |
+| [cfex-cli](https://github.com/muthuishere/cfex-cli) | CLI to expose local services to the internet via Cloudflare Tunnels on your own domain, in one command — no port forwarding, no static IP. | | Maintaining |
 
 ## Acceleration
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 | 名称                                                            | 特性                                                                                                              | 在线地址 | 状态   |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | ------ |
 | [Cloudflared-web](https://github.com/WisdomSky/Cloudflared-web) | Cloudflared-web 是一个 docker 镜像，它打包了 cloudflared cli 和简单的 Web UI，以便轻松启动/停止 cloudflare 隧道。 |          | 维护中 |
+| [cfex-cli](https://github.com/muthuishere/cfex-cli)             | 命令行工具，通过 Cloudflare Tunnel 将本地服务用自己的域名暴露到公网，无需端口转发或静态 IP，一条命令即可创建 HTTPS 端点。                                        |          | 维护中 |
 
 ## 加速
 


### PR DESCRIPTION
cfex-cli is a CLI to expose local services to the internet via Cloudflare Tunnels on your own domain — one command, no port forwarding, no static IP. Adds an entry to the Tunnel (隧道) section in README.md and README-EN.md, matching the existing table format.