### PR TITLE
开发者工具: 添加 AnyHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@
 | [HackMyIP](https://hackmyip.com/) | 基于 Cloudflare Workers 构建的在线隐私与网络工具集，提供 IP 查询、DNS/WebRTC 泄露检测、端口扫描、邮箱泄露检查、密码强度检测、网速测试等 20+ 工具，免费无需注册。 | <https://hackmyip.com/> | 维护中 |
 | [Dualmark](https://github.com/dodopayments/dualmark) | 开源 AEO（Answer Engine Optimization）基础设施。`@dualmark/cloudflare` 适配器包装任意上游 Worker，在边缘通过 HTTP 内容协商为 AI 爬虫（GPTBot、ClaudeBot、PerplexityBot 等 19 个已知 UA）返回干净的 Markdown 副本，人类访客获得 HTML，同一 URL 双格式。Apache 2.0，npm provenance 签名。 | <https://dualmark.dev> | 维护中 |
 | [shopify-attribution-gap-backend](https://github.com/lsb11/shopify-attribution-gap-backend) | 基于 Cloudflare Workers + D1 的边缘数据收集后端，用于构建开放、透明的 Shopify iOS 归因差距基准。服务端计算归因差距、人工审核机制、中位数聚合，无需服务器。 | <https://stackarchitect.xyz/shopify-ios-attribution-gap-benchmark/> | 维护中 |
+| [AnyHook](https://anyhook.net) | 入站 Webhook 中继。把 Stripe、GitHub、Shopify 这类 webhook 地址改指向它，事件先存下来再投递到你的服务器，失败按退避重试，每次请求的 headers 和 body 都留着可以回头翻。边缘入口跑在 Cloudflare Workers 上，免费额度 3000 事件/月。 | <https://anyhook.net> | 维护中 |
 
 ## 文章
 


### PR DESCRIPTION
加一条入站 webhook 中继。

边缘入口是 Cloudflare Workers，收到事件先落库再往用户自己的服务器投递，投不进去就按退避重试，请求的 headers 和 body 都留着，事后能翻能重放。

放在开发者工具这一节，紧挨着 Webhook Debugger — 那条做的是自托管的调试，这条做的是托管的投递，算是同一件事的两头。

在线地址填了 <https://anyhook.net>，免费额度 3000 事件/月，不用信用卡。