### PR TITLE
优化项：补充 Cloudflare Pages SEO 发布检查资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@
 | [cloudflare-quickstart](https://github.com/zgimszhd61/cloudflare-quickstart)                                                         | 一个快速入门指南,帮助您开始使用 Cloudflare Workers                                    |          | 更新中 |
 | [cloudflare-tunnel](https://dmesg.app/cloudflare)                                                                                    | 一系列关于如何使用 Cloudflare Zero Trust 创建大内网以及解决被墙服务器问题的技术博客。 |          | 更新中 |
 | [cloudflare-worker-gmail-resend-enterprise-email](https://cleanclip.cc/zh/developer/cloudflare-worker-gmail-resend-enterprise-email) | Cloudflare + Gmail + Resend 十分钟轻松拥有免费的企业邮箱。                            |          | 更新中 |
+| [Cloudflare Pages SEO 发布检查](https://yicekit.com/entries/cloudflare-pages/)                                                     | 用六个本站实际 HTTP 响应核对 200、301、404、canonical、robots.txt 和 sitemap.xml，附只读 curl 命令与 JSON 记录。 | [检查清单](https://yicekit.com/assets/checklists/cloudflare-pages-seo.txt) | 更新中 |
 
 
 


### PR DESCRIPTION
## 为什么补充

Cloudflare Pages 部署后，开发者常需要分别核对正常页、重复网址、缺失页、canonical、robots.txt 和 sitemap.xml。现有教程列表尚未提供一份可直接复查这些响应的中文清单。

## 本次改动

在中文 README 的“教程”栏目增加一条 YiceKit 资源：

- 记录本站在 2026-08-31 的六个实际 HTTP GET 响应；
- 提供只读 `curl` 命令；
- 附可下载 TXT 清单和 JSON 原始记录；
- 明确这些是本站配置结果，不代表所有 Pages 站点的默认行为，也不保证收录或排名。

我是 YiceKit 站点维护者。本 PR 只增加一行资源链接，不修改其他条目，也不带 UTM 参数。
