### PR TITLE
Add CostGoat to Others section

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -249,6 +249,7 @@ Feel free to submit PRs and issues to update the content. If you have any questi
 | [OmniConvert](https://github.com/s87343472/omni-convert) | Free online conversion toolbox deployed on Cloudflare Pages + Workers. Supports file conversion, unit conversion, PWA, multilingual UI, and API/MCP access. | <https://tools.sagasu.art> | Maintaining |
 | [Dualmark](https://github.com/dodopayments/dualmark) | Open-source AEO (Answer Engine Optimization) infrastructure. The `@dualmark/cloudflare` adapter wraps any upstream Worker and serves clean Markdown twins to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 more known UAs) at the edge via HTTP content negotiation, while humans get HTML — same URL, two formats. Apache 2.0, npm provenance attested. | <https://dualmark.dev> | Maintaining |
 | [shopify-attribution-gap-backend](https://github.com/lsb11/shopify-attribution-gap-backend) | Edge data-collection backend on Cloudflare Workers + D1 for an open Shopify iOS attribution-gap benchmark. Server-side gap computation, manual review gate, median aggregation, no server needed. | <https://stackarchitect.xyz/shopify-ios-attribution-gap-benchmark/> | Maintaining |
+| [CostGoat](https://costgoat.com) | Desktop app that tracks your Cloudflare spend for the current billing cycle and alerts you before it gets out of hand. Also covers other cloud and AI services. | <https://costgoat.com> | Active |
 
 
 ## Tutorials

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@
 | [Slitherlinks](https://slitherlinks.com)                                                                                       | 免费在线 Slitherlink 数字回路谜题平台，提供 1900+ 谜题、每日挑战、全球排行榜，技术栈包含 Cloudflare Workers + D1。                                                                                                                                                     | <https://slitherlinks.com>                                                                   | 维护中       |
 | [Flashify](https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1)                           | AI 驱动的学习工具，可将 PDF 学习资料转换为高质量 Anki 闪卡并导出卡组。                                                                                                                                                                                                 | <https://flashify.app?utm_source=github&utm_medium=directory&utm_campaign=backlink-2026q1>   | 维护中       |
 | [Voidly Messenger](https://github.com/voidly-ai)                                                                               | 完全基于 Cloudflare 构建的端到端加密消息 PWA（Pages + Workers + D1 + KV）。采用 Signal Protocol（Double Ratchet + X3DH）与 ML-KEM-768 后量子混合加密，全部加密在客户端完成，Workers 无法读取明文。                                                                     | <https://msg.voidly.ai>                                                                      | 维护中       |
+| [CostGoat](https://costgoat.com) | 桌面应用，跟踪当前计费周期的 Cloudflare 费用，并在超出预算前提醒你。同时支持其他云服务与 AI 服务。 | <https://costgoat.com> | 维护中 |
 
 ## 教程
 


### PR DESCRIPTION
Adds CostGoat to the Others section in both README.md and README-EN.md.

CostGoat is a desktop app that tracks Cloudflare spend and alerts you before it gets out of hand. It is not built on Cloudflare, so I have put it in Others with the other external tools rather than in a Workers section.

Disclosure: I built it.